### PR TITLE
feat: 指修正ツール（FingerFixTab）を追加

### DIFF
--- a/create_characters/character-pose/src/App.tsx
+++ b/create_characters/character-pose/src/App.tsx
@@ -1,13 +1,91 @@
 /**
  * アプリケーションのルートコンポーネント
+ * タブナビゲーション機能とデータ連携機能を提供
  *
  * @returns JSX.Element
  */
 
+import { useState, type JSX } from 'react';
 import CharacterPoseGenerator from "./components/CharacterPoseGenerator";
+import CharacterDesigner from "./components/CharacterDesigner";
+import FingerFixTab from "./components/FingerFixTab";
 
-const App: React.FC = () => {
-    return <CharacterPoseGenerator />;
+interface GeneratedImage {
+  prompt: string;
+  imageUrl: string;
+  index: number;
+  selected: boolean;
+}
+
+type ActiveTab = 'design' | 'pose' | 'fix';
+
+const App: React.FC = (): JSX.Element => {
+    const [activeTab, setActiveTab] = useState<ActiveTab>('design');
+    const [designedCharacter, setDesignedCharacter] = useState<GeneratedImage | null>(null);
+    const [fingerFixImageUrl, setFingerFixImageUrl] = useState<string | null>(null);
+
+    const handleCharacterSelect = (character: GeneratedImage): void => {
+        setDesignedCharacter(character);
+        setActiveTab('pose');
+    };
+
+    const handleOpenFingerFix = (imageUrl: string): void => {
+        setFingerFixImageUrl(imageUrl);
+        setActiveTab('fix');
+    };
+
+    return (
+        <div className="min-h-screen w-screen bg-gradient-to-br from-purple-50 to-pink-50">
+            <div className="max-w-7xl mx-auto">
+                {/* タブナビゲーション */}
+                <div className="flex justify-center p-6">
+                    <div className="bg-white rounded-lg shadow-md p-1 flex">
+                        <button
+                            onClick={() => setActiveTab('design')}
+                            className={`px-6 py-3 rounded-md font-semibold transition-all ${
+                                activeTab === 'design'
+                                    ? 'bg-purple-600 text-white shadow-md'
+                                    : 'text-gray-600 hover:bg-gray-100'
+                            }`}
+                        >
+                            キャラデザイナー
+                        </button>
+                        <button
+                            onClick={() => setActiveTab('pose')}
+                            className={`px-6 py-3 rounded-md font-semibold transition-all ${
+                                activeTab === 'pose'
+                                    ? 'bg-purple-600 text-white shadow-md'
+                                    : 'text-gray-600 hover:bg-gray-100'
+                            }`}
+                        >
+                            ポーズ生成
+                        </button>
+                        <button
+                            onClick={() => setActiveTab('fix')}
+                            className={`px-6 py-3 rounded-md font-semibold transition-all ${
+                                activeTab === 'fix'
+                                    ? 'bg-orange-600 text-white shadow-md'
+                                    : 'text-gray-600 hover:bg-gray-100'
+                            }`}
+                        >
+                            指修正
+                        </button>
+                    </div>
+                </div>
+
+                {/* タブコンテンツ */}
+                {activeTab === 'design' && (
+                    <CharacterDesigner onCharacterSelect={handleCharacterSelect} />
+                )}
+                {activeTab === 'pose' && (
+                    <CharacterPoseGenerator designedCharacter={designedCharacter} onOpenFingerFix={handleOpenFingerFix} />
+                )}
+                {activeTab === 'fix' && (
+                    <FingerFixTab initialImageUrl={fingerFixImageUrl} onImageConsumed={() => setFingerFixImageUrl(null)} />
+                )}
+            </div>
+        </div>
+    );
 };
 
 export default App;

--- a/create_characters/character-pose/src/components/CharacterDesigner.tsx
+++ b/create_characters/character-pose/src/components/CharacterDesigner.tsx
@@ -1,0 +1,847 @@
+/**
+ * キャラクターデザインコンポーネント
+ * 4項目選択システム（種族、職業、テーマカラー、LPトーン）でキャラクターを設計し、
+ * 4バリエーション画像を生成する
+ */
+
+import { useState, type JSX } from 'react';
+import {
+  Palette,
+  Users,
+  Briefcase,
+  Heart,
+  Shuffle,
+  Dice6,
+  Copy,
+  Wand2,
+  X,
+  ArrowRight,
+} from 'lucide-react';
+
+interface GeneratedImage {
+  prompt: string;
+  imageUrl: string;
+  index: number;
+  selected: boolean;
+}
+
+interface CharacterDesignerProps {
+  onCharacterSelect: (character: GeneratedImage) => void;
+}
+
+const CharacterDesigner: React.FC<CharacterDesignerProps> = ({ onCharacterSelect }): JSX.Element => {
+  // ==================== 設定 ====================
+  const USE_REAL_API = true; // true: 実際のAPI、false: モック機能
+
+  // ==================== State管理 ====================
+  const [selectedMotif, setSelectedMotif] = useState<string>('');
+  const [selectedOccupation, setSelectedOccupation] = useState<string>('');
+  const [selectedColor, setSelectedColor] = useState<string>('#FF6B6B');
+  const [selectedTone, setSelectedTone] = useState<string>('');
+
+  const [customMotif, setCustomMotif] = useState<string>('');
+  const [customOccupation, setCustomOccupation] = useState<string>('');
+  const [customTone, setCustomTone] = useState<string>('');
+
+  // モチーフカテゴリ選択
+  const [activeMotifCategory, setActiveMotifCategory] = useState<'human' | 'animal' | 'fantasy'>('human');
+
+  // 人間の場合の詳細選択
+  const [selectedGender, setSelectedGender] = useState<string>('');
+  const [selectedAgeGroup, setSelectedAgeGroup] = useState<string>('');
+
+  const [generatedImages, setGeneratedImages] = useState<GeneratedImage[]>([]);
+  const [isGenerating, setIsGenerating] = useState<boolean>(false);
+  const [modalImageUrl, setModalImageUrl] = useState<string | null>(null);
+
+  // プロンプト編集機能
+  const [isEditingPrompt, setIsEditingPrompt] = useState<boolean>(false);
+  const [customPrompt, setCustomPrompt] = useState<string>('');
+
+  // ==================== データ定義 ====================
+  const motifCategories = {
+    human: {
+      name: '人間',
+      genders: [
+        { id: 'male', name: '男性' },
+        { id: 'female', name: '女性' },
+      ],
+      ageGroups: [
+        { id: 'child', name: '子供' },
+        { id: 'youth', name: '青年' },
+        { id: 'adult', name: '大人' },
+        { id: 'middle', name: '中年' },
+        { id: 'elder', name: '老人' },
+      ]
+    },
+    animal: {
+      name: '動物',
+      items: [
+        { id: 'cat', name: '猫' },
+        { id: 'dog', name: '犬' },
+        { id: 'wolf', name: '狼' },
+        { id: 'fox', name: '狐' },
+        { id: 'rabbit', name: 'うさぎ' },
+        { id: 'bear', name: '熊' },
+        { id: 'panda', name: 'パンダ' },
+        { id: 'lion', name: 'ライオン' },
+        { id: 'tiger', name: 'トラ' },
+        { id: 'horse', name: '馬' },
+        { id: 'bird', name: '鳥' },
+        { id: 'owl', name: 'ふくろう' },
+        { id: 'hawk', name: '鷹' },
+        { id: 'penguin', name: 'ペンギン' },
+        { id: 'dolphin', name: 'イルカ' },
+        { id: 'shark', name: 'サメ' },
+        { id: 'snake', name: 'ヘビ' },
+        { id: 'lizard', name: 'トカゲ' },
+      ]
+    },
+    fantasy: {
+      name: '空想上の生き物',
+      items: [
+        { id: 'dragon', name: 'ドラゴン' },
+        { id: 'ryu', name: '龍' },
+        { id: 'unicorn', name: 'ユニコーン' },
+        { id: 'phoenix', name: 'フェニックス' },
+        { id: 'angel', name: '天使' },
+        { id: 'demon', name: '悪魔' },
+        { id: 'fairy', name: '妖精' },
+        { id: 'elf', name: 'エルフ' },
+        { id: 'centaur', name: 'ケンタウロス' },
+        { id: 'mermaid', name: 'マーメイド' },
+        { id: 'griffin', name: 'グリフォン' },
+        { id: 'minotaur', name: 'ミノタウロス' },
+      ]
+    }
+  };
+
+  const occupations = [
+    '弁護士', '税理士', '司法書士', '行政書士', '社労士', '会計士', '医師', '歯科医師',
+    '薬剤師', '獣医師', 'カウンセラー', '整体師', '美容師', 'エステティシャン', 'ネイリスト',
+    'マッサージ師', 'トレーナー', '料理人', '水道工事', '電気工事', 'リフォーム', '清掃業',
+    '引越し業', '害虫駆除', '不動産', '保険代理店', 'コンサルタント', 'カーディーラー',
+    '車検・修理', 'IT企業'
+  ];
+
+  const colors = [
+    { hex: '#FF1414', name: '赤' },
+    { hex: '#4ECDC4', name: '青緑' },
+    { hex: '#264AD9', name: '青' },
+    { hex: '#16A10C', name: '緑' },
+    { hex: '#FECA57', name: '黄' },
+    { hex: '#9B59B6', name: '紫' },
+    { hex: '#FF9FF3', name: 'ピンク' },
+    { hex: '#2C3E50', name: '黒' },
+    { hex: '#FFFFFF', name: '白' },
+    { hex: '#F39C12', name: '金' },
+    { hex: '#95A5A6', name: '銀' },
+    { hex: '#FF6348', name: 'オレンジ' },
+  ];
+
+  const tones = [
+    '真面目・信頼感', 'ポップ・親しみやすい', '和風・伝統的',
+    'ジブリ', 'カートゥーン', 'リアル',
+  ];
+
+  // ==================== ヘルパー関数 ====================
+  const generateMotifString = (): string => {
+    if (customMotif.trim()) return customMotif.trim();
+
+    if (activeMotifCategory === 'human') {
+      if (selectedGender && selectedAgeGroup) {
+        const genderName = motifCategories.human.genders.find(g => g.id === selectedGender)?.name || '';
+        const ageName = motifCategories.human.ageGroups.find(a => a.id === selectedAgeGroup)?.name || '';
+        return `${genderName}の${ageName}`;
+      }
+    } else {
+      return selectedMotif;
+    }
+
+    return '';
+  };
+
+  const generatePrompt = (): string => {
+    if (isEditingPrompt && customPrompt.trim()) {
+      return customPrompt.trim();
+    }
+
+    const motif = generateMotifString();
+    const occupation = customOccupation || selectedOccupation;
+    const tone = customTone || selectedTone;
+
+    return `A ${motif} character working as ${occupation}, wearing ${selectedColor} colored clothing or outfit in ${tone} style, standing upright with both arms spread wide, looking directly at viewer, completely transparent background with no objects or scenery, anthropomorphic hands with exactly 5 fingers on each hand, fingers clearly separated and detailed, does not hold anything in hands, open hands, professional illustration, high quality, detailed character design`;
+  };
+
+  const getAutoGeneratedPrompt = (): string => {
+    const motif = generateMotifString();
+    const occupation = customOccupation || selectedOccupation;
+    const tone = customTone || selectedTone;
+
+    return `A ${motif} character working as ${occupation}, wearing ${selectedColor} colored clothing or outfit in ${tone} style, standing upright with both arms spread wide, looking directly at viewer, completely transparent background with no objects or scenery, anthropomorphic hands with exactly 5 fingers on each hand, fingers clearly separated and detailed, does not hold anything in hands, open hands, professional illustration, high quality, detailed character design`;
+  };
+
+  const isFormValid = (): boolean => {
+    if (isEditingPrompt) {
+      return customPrompt.trim().length > 0;
+    }
+
+    const hasMotif = generateMotifString().length > 0;
+    const hasOccupation = selectedOccupation || customOccupation.trim();
+    const hasTone = selectedTone || customTone.trim();
+    return !!(hasMotif && hasOccupation && hasTone);
+  };
+
+  // ==================== イベントハンドラー ====================
+  const handleRandomMotif = (): void => {
+    const categories = ['human', 'animal', 'fantasy'] as const;
+    const randomCategory = categories[Math.floor(Math.random() * categories.length)];
+
+    setActiveMotifCategory(randomCategory);
+    setCustomMotif('');
+
+    if (randomCategory === 'human') {
+      const randomGender = motifCategories.human.genders[Math.floor(Math.random() * motifCategories.human.genders.length)];
+      const randomAge = motifCategories.human.ageGroups[Math.floor(Math.random() * motifCategories.human.ageGroups.length)];
+      setSelectedGender(randomGender.id);
+      setSelectedAgeGroup(randomAge.id);
+      setSelectedMotif('');
+    } else {
+      const items = motifCategories[randomCategory].items;
+      const random = items[Math.floor(Math.random() * items.length)];
+      setSelectedMotif(random.name);
+      setSelectedGender('');
+      setSelectedAgeGroup('');
+    }
+  };
+
+  const handleRandomOccupation = (): void => {
+    const random = occupations[Math.floor(Math.random() * occupations.length)];
+    setSelectedOccupation(random);
+    setCustomOccupation('');
+  };
+
+  const handleRandomColor = (): void => {
+    const random = colors[Math.floor(Math.random() * colors.length)];
+    setSelectedColor(random.hex);
+  };
+
+  const handleRandomTone = (): void => {
+    const random = tones[Math.floor(Math.random() * tones.length)];
+    setSelectedTone(random);
+    setCustomTone('');
+  };
+
+  const handleRandomAll = (): void => {
+    handleRandomMotif();
+    handleRandomOccupation();
+    handleRandomColor();
+    handleRandomTone();
+  };
+
+  const copyPrompt = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(generatePrompt());
+      alert('プロンプトをコピーしました！');
+    } catch (err) {
+      console.error('コピーに失敗しました:', err);
+    }
+  };
+
+  /** API Gateway 呼び出し */
+  const callCharacterAPI = async (prompt: string): Promise<string> => {
+    try {
+      const response = await fetch('/api/nano-banana', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          prompt: prompt,
+          negative_prompt: 'low quality, blurry, bad anatomy, deformed, cropped, out of frame, extra fingers, six fingers, fewer than five fingers, fused fingers, missing fingers, malformed, hands, paws, claws, background objects, scenery, furniture, props, items, decorations, landscape, sky, ground, floor, walls',
+          seed: Math.floor(Math.random() * 1000000),
+          steps: 30,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`HTTP ${response.status}: ${errorText}`);
+      }
+
+      const data = await response.json();
+
+      // FAL APIの実際のレスポンス形式に対応
+      if (data.images && data.images[0] && data.images[0].url) {
+        return data.images[0].url;
+      }
+
+      // エラーレスポンスの場合
+      if (data.error || data.detail) {
+        throw new Error(data.error || data.detail || '画像の取得に失敗しました');
+      }
+
+      throw new Error('不明なレスポンス形式です');
+    } catch (err) {
+      console.error('API 呼び出しエラー:', err);
+      throw new Error('画像の生成中にエラーが発生しました');
+    }
+  };
+
+  const generateCharacterImages = async (): Promise<void> => {
+    if (!isFormValid()) {
+      alert('すべての項目を選択してください');
+      return;
+    }
+
+    setIsGenerating(true);
+    setGeneratedImages([]);
+
+    try {
+      const basePrompt = generatePrompt();
+      const variations = [
+        {
+          name: '基本',
+          suffix: '',
+          description: 'basic pose'
+        },
+        {
+          name: '表情変更',
+          suffix: ', smiling happily with cheerful expression',
+          description: 'happy expression'
+        },
+        {
+          name: '服装変更',
+          suffix: ', wearing different style of professional attire',
+          description: 'different outfit'
+        },
+        {
+          name: '顔変更',
+          suffix: ', with different face',
+          description: 'different face'
+        },
+      ];
+
+      const results: GeneratedImage[] = [];
+
+      for (let i = 0; i < 4; i++) {
+        const variation = variations[i];
+        const prompt = basePrompt + variation.suffix;
+
+        try {
+          let imageUrl: string;
+
+          if (USE_REAL_API) {
+            // 実際のAPI呼び出し
+            imageUrl = await callCharacterAPI(prompt);
+          } else {
+            // モック画像生成（2秒の遅延をシミュレート）
+            await new Promise(resolve => setTimeout(resolve, 2000));
+            const svgContent = `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512"><rect width="512" height="512" fill="white"/><rect x="100" y="150" width="312" height="200" fill="${selectedColor}" opacity="0.8"/><text x="50%" y="40%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="20" fill="#333">${variation.name}</text><text x="50%" y="60%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" fill="#666">${generateMotifString()}</text></svg>`;
+            imageUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgContent)}`;
+          }
+
+          results.push({
+            prompt,
+            imageUrl,
+            index: i,
+            selected: false,
+          });
+        } catch (error) {
+          console.error(`バリエーション${i + 1}の生成に失敗:`, error);
+          // エラー時のフォールバック画像
+          const errorText = `Error: ${i + 1}`;
+          const svgContent = `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512"><rect width="512" height="512" fill="#ffebee"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="16" fill="#c62828">${errorText}</text></svg>`;
+          const mockImageUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgContent)}`;
+
+          results.push({
+            prompt,
+            imageUrl: mockImageUrl,
+            index: i,
+            selected: false,
+          });
+        }
+
+        setGeneratedImages([...results]);
+
+        // 次のリクエストまで少し待機（API制限回避）
+        if (i < 3) {
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        }
+      }
+    } catch (error) {
+      console.error('画像生成処理全体でエラーが発生:', error);
+      alert('画像生成中にエラーが発生しました。しばらく待ってから再度お試しください。');
+    } finally {
+      // 必ずボタンの状態をリセット
+      setIsGenerating(false);
+    }
+  };
+
+  const openModal = (url: string): void => setModalImageUrl(url);
+  const closeModal = (): void => setModalImageUrl(null);
+
+  // ==================== JSX ====================
+  return (
+    <>
+      {/* モーダル */}
+      {modalImageUrl && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          onClick={closeModal}
+        >
+          <div
+            className="relative bg-white p-4 rounded-lg shadow-lg max-w-[90vw] max-h-[90vh]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={closeModal}
+              className="absolute -right-3 -top-3 w-8 h-8 rounded-full bg-red-600 text-white flex items-center justify-center shadow"
+            >
+              <X size={16} />
+            </button>
+            <img src={modalImageUrl} alt="preview" className="max-w-full max-h-[80vh]" />
+          </div>
+        </div>
+      )}
+
+      <div className="p-6">
+        <div className="bg-white rounded-xl shadow-lg p-8">
+          <h1 className="text-3xl font-bold text-center mb-8 text-purple-800">
+            <Wand2 className="inline-block mr-3" />
+            キャラクターデザイナー
+          </h1>
+
+          {/* 設定項目グリッド */}
+          <div className="grid md:grid-cols-2 gap-8 mb-8">
+            {/* モチーフ選択 */}
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-pink-800 flex items-center">
+                  <Users className="mr-2" />
+                  モチーフ
+                </h3>
+                <button
+                  onClick={handleRandomMotif}
+                  className="p-2 bg-pink-100 text-pink-600 rounded-lg hover:bg-pink-200"
+                >
+                  <Shuffle size={16} />
+                </button>
+              </div>
+
+              {/* カスタム入力 */}
+              <input
+                type="text"
+                value={customMotif}
+                onChange={(e) => {
+                  setCustomMotif(e.target.value);
+                  if (e.target.value.trim()) {
+                    setSelectedMotif('');
+                    setSelectedGender('');
+                    setSelectedAgeGroup('');
+                  }
+                }}
+                placeholder="カスタムモチーフを入力..."
+                className="w-full p-2 border border-gray-300 rounded focus:border-pink-400 focus:outline-none mb-4"
+              />
+
+              {/* カテゴリタブ */}
+              <div className="flex border-b border-pink-200 mb-4">
+                {Object.entries(motifCategories).map(([key, category]) => (
+                  <button
+                    key={key}
+                    onClick={() => {
+                      setActiveMotifCategory(key as 'human' | 'animal' | 'fantasy');
+                      setSelectedMotif('');
+                      setCustomMotif('');
+                      setSelectedGender('');
+                      setSelectedAgeGroup('');
+                    }}
+                    className={`px-4 py-2 font-medium text-sm border-b-2 transition-colors ${
+                      activeMotifCategory === key
+                        ? 'border-pink-500 text-pink-700'
+                        : 'border-transparent hover:border-pink-300'
+                    }`}
+                  >
+                    {category.name}
+                  </button>
+                ))}
+              </div>
+
+              {/* 人間の場合の性別・年齢層選択 */}
+              {activeMotifCategory === 'human' && (
+                <div className="space-y-4">
+                  {/* 性別選択 */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">性別</label>
+                    <div className="grid grid-cols-3 gap-2">
+                      {motifCategories.human.genders.map((gender) => (
+                        <button
+                          key={gender.id}
+                          onClick={() => setSelectedGender(gender.id)}
+                          className={`p-2 text-sm rounded border text-center hover:bg-pink-50 ${
+                            selectedGender === gender.id
+                              ? 'bg-pink-100 border-pink-400 text-pink-800'
+                              : 'border-gray-200'
+                          }`}
+                        >
+                          {gender.name}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* 年齢層選択 */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">年齢層</label>
+                    <div className="grid grid-cols-3 gap-2">
+                      {motifCategories.human.ageGroups.map((age) => (
+                        <button
+                          key={age.id}
+                          onClick={() => setSelectedAgeGroup(age.id)}
+                          className={`p-2 text-sm rounded border text-center hover:bg-pink-50 ${
+                            selectedAgeGroup === age.id
+                              ? 'bg-pink-100 border-pink-400 text-pink-800'
+                              : 'border-gray-200'
+                          }`}
+                        >
+                          {age.name}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* 動物・空想上の生き物の場合のプリセット選択 */}
+              {activeMotifCategory !== 'human' && (
+                <div className="grid grid-cols-2 gap-2 mb-4 max-h-40 overflow-y-auto">
+                  {motifCategories[activeMotifCategory].items.map((item) => (
+                    <button
+                      key={item.id}
+                      onClick={() => {
+                        setSelectedMotif(item.name);
+                        setCustomMotif('');
+                        setSelectedGender('');
+                        setSelectedAgeGroup('');
+                      }}
+                      className={`p-2 text-sm rounded border text-left hover:bg-pink-50 ${
+                        selectedMotif === item.name
+                          ? 'bg-pink-100 border-pink-400 text-pink-800'
+                          : 'border-gray-200'
+                      }`}
+                    >
+                      {item.name}
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {/* 選択中表示 */}
+              <div className="mt-2 h-10 flex items-center">
+                {generateMotifString() && (
+                  <div className="p-2 bg-pink-50 rounded text-sm w-full">
+                    選択中: <span className="font-semibold text-pink-700">
+                      {generateMotifString()}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* 職業選択 */}
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-green-800 flex items-center">
+                  <Briefcase className="mr-2" />
+                  職業
+                </h3>
+                <button
+                  onClick={handleRandomOccupation}
+                  className="p-2 bg-green-100 text-green-600 rounded-lg hover:bg-green-200"
+                >
+                  <Shuffle size={16} />
+                </button>
+              </div>
+              {/* カスタム入力 */}
+              <input
+                type="text"
+                value={customOccupation}
+                onChange={(e) => {
+                  setCustomOccupation(e.target.value);
+                  if (e.target.value.trim()) setSelectedOccupation('');
+                }}
+                placeholder="カスタム職業を入力..."
+                className="w-full p-2 border border-gray-300 rounded focus:border-green-400 focus:outline-none mb-4"
+              />
+
+              {/* プリセット選択 */}
+              <div className="grid grid-cols-2 gap-2 mb-4 max-h-40 overflow-y-auto">
+                {occupations.map((occupation) => (
+                  <button
+                    key={occupation}
+                    onClick={() => {
+                      setSelectedOccupation(occupation);
+                      setCustomOccupation('');
+                    }}
+                    className={`p-2 text-sm rounded border text-left hover:bg-green-50 ${
+                      selectedOccupation === occupation
+                        ? 'bg-green-100 border-green-400 text-green-800'
+                        : 'border-gray-200'
+                    }`}
+                  >
+                    {occupation}
+                  </button>
+                ))}
+              </div>
+
+              {/* 選択中表示 */}
+              <div className="mt-2 h-10 flex items-center">
+                {(selectedOccupation || customOccupation) && (
+                  <div className="p-2 bg-green-50 rounded text-sm w-full">
+                    選択中: <span className="font-semibold text-green-700">
+                      {customOccupation || selectedOccupation}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* テーマカラー選択 */}
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-orange-800 flex items-center">
+                  <Palette className="mr-2" />
+                  テーマカラー
+                </h3>
+                <button
+                  onClick={handleRandomColor}
+                  className="p-2 bg-orange-100 text-orange-600 rounded-lg hover:bg-orange-200"
+                >
+                  <Shuffle size={16} />
+                </button>
+              </div>
+              {/* プリセット色選択 */}
+              <div className="grid grid-cols-4 gap-2 mb-4">
+                {colors.map((color) => (
+                  <button
+                    key={color.hex}
+                    onClick={() => setSelectedColor(color.hex)}
+                    className={`w-full h-12 rounded border-2 flex flex-col items-center justify-center text-xs font-semibold ${
+                      selectedColor === color.hex
+                        ? 'border-orange-400 ring-2 ring-orange-200'
+                        : 'border-gray-300 hover:border-orange-300'
+                    }`}
+                    style={{
+                      backgroundColor: color.hex,
+                      color: color.hex === '#FFFFFF' || color.hex === '#FECA57' ? '#000' : '#fff'
+                    }}
+                  >
+                    {color.name}
+                  </button>
+                ))}
+              </div>
+
+              {/* HEX入力 */}
+              <div className="flex gap-2 mb-4">
+                <input
+                  type="text"
+                  value={selectedColor}
+                  onChange={(e) => setSelectedColor(e.target.value)}
+                  placeholder="#FF6B6B"
+                  className="flex-1 p-2 border border-gray-300 rounded focus:border-orange-400 focus:outline-none"
+                />
+                <input
+                  type="color"
+                  value={selectedColor}
+                  onChange={(e) => setSelectedColor(e.target.value)}
+                  className="w-12 h-10 border border-gray-300 rounded cursor-pointer"
+                />
+              </div>
+
+              {/* 選択中表示 */}
+              <div className="h-14 flex items-center">
+                <div className="p-3 bg-orange-50 rounded flex items-center gap-3 w-full">
+                  <div
+                    className="w-8 h-8 rounded border border-gray-300"
+                    style={{ backgroundColor: selectedColor }}
+                  />
+                  <span className="text-sm font-semibold text-orange-700">
+                    {selectedColor}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* LPトーン選択 */}
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-purple-800 flex items-center">
+                  <Heart className="mr-2" />
+                  LPトーン
+                </h3>
+                <button
+                  onClick={handleRandomTone}
+                  className="p-2 bg-purple-100 text-purple-600 rounded-lg hover:bg-purple-200"
+                >
+                  <Shuffle size={16} />
+                </button>
+              </div>
+              {/* カスタム入力 */}
+              <input
+                type="text"
+                value={customTone}
+                onChange={(e) => {
+                  setCustomTone(e.target.value);
+                  if (e.target.value.trim()) setSelectedTone('');
+                }}
+                placeholder="カスタムトーンを入力..."
+                className="w-full p-2 border border-gray-300 rounded focus:border-purple-400 focus:outline-none mb-4"
+              />
+
+              {/* プリセット選択 */}
+              <div className="grid grid-cols-2 gap-2 mb-4 max-h-40 overflow-y-auto">
+                {tones.map((tone) => (
+                  <button
+                    key={tone}
+                    onClick={() => {
+                      setSelectedTone(tone);
+                      setCustomTone('');
+                    }}
+                    className={`p-2 text-sm rounded border text-left hover:bg-purple-50 ${
+                      selectedTone === tone
+                        ? 'bg-purple-100 border-purple-400 text-purple-800'
+                        : 'border-gray-200'
+                    }`}
+                  >
+                    {tone}
+                  </button>
+                ))}
+              </div>
+
+              {/* 選択中表示 */}
+              <div className="mt-2 h-10 flex items-center">
+                {(selectedTone || customTone) && (
+                  <div className="p-2 bg-purple-50 rounded text-sm w-full">
+                    選択中: <span className="font-semibold text-purple-700">
+                      {customTone || selectedTone}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* プロンプトプレビュー・編集 */}
+          <div className="mb-8 p-4 bg-gray-50 rounded-lg">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-4">
+              <h3 className="font-semibold text-gray-700">生成プロンプト</h3>
+              <div className="flex gap-2 flex-shrink-0">
+                <button
+                  onClick={() => {
+                    if (!isEditingPrompt) {
+                      setCustomPrompt(getAutoGeneratedPrompt());
+                    }
+                    setIsEditingPrompt(!isEditingPrompt);
+                  }}
+                  className={`px-3 py-2 rounded text-sm whitespace-nowrap ${
+                    isEditingPrompt
+                      ? 'bg-blue-600 text-white hover:bg-blue-700'
+                      : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
+                  }`}
+                >
+                  {isEditingPrompt ? '自動生成に戻す' : 'プロンプト編集'}
+                </button>
+                <button
+                  onClick={() => void copyPrompt()}
+                  className="p-2 bg-gray-200 text-gray-600 rounded hover:bg-gray-300 flex-shrink-0"
+                >
+                  <Copy size={16} />
+                </button>
+              </div>
+            </div>
+
+            <div className="min-h-0">
+              {isEditingPrompt ? (
+                <div className="space-y-2">
+                  <textarea
+                    value={customPrompt}
+                    onChange={(e) => setCustomPrompt(e.target.value)}
+                    className="w-full p-3 border border-gray-300 rounded-lg focus:border-blue-400 focus:outline-none resize-vertical min-h-[6rem]"
+                    rows={4}
+                    placeholder="カスタムプロンプトを入力してください..."
+                  />
+                  <p className="text-xs text-gray-500">
+                    プロンプトを直接編集できます。「自動生成に戻す」ボタンで元の自動生成に戻せます。
+                  </p>
+                </div>
+              ) : (
+                <div className="min-h-[6rem] flex items-start">
+                  <p className="text-sm text-gray-600 break-words leading-relaxed">{generatePrompt()}</p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* アクションボタン */}
+          <div className="flex flex-wrap gap-4 justify-center mb-8">
+            <button
+              onClick={handleRandomAll}
+              className="px-6 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 flex items-center"
+            >
+              <Dice6 className="mr-2" size={20} />
+              全ランダム
+            </button>
+            <button
+              onClick={() => void generateCharacterImages()}
+              disabled={!isFormValid() || isGenerating}
+              className="px-8 py-3 bg-pink-600 text-white rounded-lg disabled:bg-gray-400 flex items-center"
+            >
+              {isGenerating ? (
+                <>
+                  <div className="animate-spin h-5 w-5 border-b-2 border-white mr-2" />
+                  生成中...
+                </>
+              ) : (
+                <>
+                  <Wand2 className="mr-2" size={20} />
+                  キャラクター生成
+                </>
+              )}
+            </button>
+          </div>
+
+          {/* 生成画像一覧 */}
+          {generatedImages.length > 0 && (
+            <div className="mt-8">
+              <h3 className="text-lg font-semibold mb-4">生成結果</h3>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                {generatedImages.map((img) => (
+                  <div key={img.index} className="border rounded-lg shadow-sm hover:shadow-md">
+                    <img
+                      src={img.imageUrl}
+                      alt={img.prompt}
+                      className="w-full h-48 object-cover rounded-t-lg cursor-pointer"
+                      onClick={() => openModal(img.imageUrl)}
+                    />
+                    <div className="p-3">
+                      <button
+                        onClick={() => onCharacterSelect(img)}
+                        className="w-full bg-purple-600 text-white py-2 px-4 rounded-lg hover:bg-purple-700 flex items-center justify-center"
+                      >
+                        このキャラでポーズ生成
+                        <ArrowRight className="ml-2" size={16} />
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default CharacterDesigner;

--- a/create_characters/character-pose/src/components/CharacterPoseGenerator.tsx
+++ b/create_characters/character-pose/src/components/CharacterPoseGenerator.tsx
@@ -1,4 +1,9 @@
-// src/components/CharacterPoseGenerator.tsx
+/**
+ * キャラクターポーズ生成コンポーネント
+ * 画像アップロード →（fal.ai API／いまはモック）でポーズ画像を生成し
+ * 個別／選択／全画像をダウンロードできる。
+ */
+
 import {
   useState,
   useRef,
@@ -12,16 +17,15 @@ import {
   Plus,
   Trash2,
   Play,
-  Settings,
   Image as ImageIcon,
   Square,
   Check,
+  Hand,
 } from 'lucide-react';
-import { createFalClient } from '@fal-ai/client';
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
 
-/* ---------- 型 ---------- */
+/** 生成済み画像の型 */
 interface GeneratedImage {
   prompt: string;
   imageUrl: string;
@@ -29,481 +33,722 @@ interface GeneratedImage {
   selected: boolean;
 }
 
-/* ---------- 本体 ---------- */
-const CharacterPoseGenerator = (): JSX.Element => {
-  /* ----- state ----- */
-  const [apiKey, setApiKey] = useState('');
+interface FingerFixState {
+  targetIndex: number;
+  candidates: string[];
+  isLoading: boolean;
+  originalUrl: string;
+}
+
+const FINGER_FIX_PROMPT =
+  'Fix both hands so that each hand clearly shows five distinct fingers with correct anatomy and proportions. Keep the rest of the image unchanged.';
+const FINGER_FIX_NEGATIVE_PROMPT =
+  'extra finger, six fingers, deformed hand, blurry, nsfw';
+
+interface CharacterPoseGeneratorProps {
+  designedCharacter?: GeneratedImage | null;
+  onOpenFingerFix?: (imageUrl: string) => void;
+}
+
+const CharacterPoseGenerator = ({ designedCharacter, onOpenFingerFix }: CharacterPoseGeneratorProps): JSX.Element => {
+  /* -------------------- state -------------------- */
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
-  const [imagePreview, setImagePreview] = useState<string | null>(null);
-
+  const [imagePreview, setImagePreview] = useState<string | null>(designedCharacter?.imageUrl || null);
   const [posePrompts, setPosePrompts] = useState<string[]>([
-    'jumping in the air happily',
-    'waving one hand energetically',
-    'dancing with a big smile',
-    'sitting calmly and looking up',
-    'floating gently as if dreaming',
-    'running while laughing',
-    'holding a tiny flag with pride',
-    'hugging a small heart',
-    'stacked on top of each other like a tower',
-    'playing with bubbles',
+      'A character is waving one hand energetically',
+      'A character is bowing calmly and looking up',
+      'A character is pointing at a clock to show the time',
+      'A character is rushing while laughing',
+      'A character is hugging a small heart',
+      'A character is pointing at a calendar',
+      'A character is calling on a phone',
+      'A character is putting a hand on right side to show the direction',
+      'A character is pointing up with one hand',
+      'A character is putting a hand on its chest with pride',
+      'Two characters are shaking hands while smiling',
   ]);
-  const [newPrompt, setNewPrompt] = useState('');
-  const [editingIdx, setEditingIdx] = useState<number | null>(null);
-  const [editingText, setEditingText] = useState('');
-
-  const [commonPrompt, setCommonPrompt] = useState('');
-
-  const [isGenerating, setIsGenerating] = useState(false);
-  const shouldStopRef = useRef(false);
-  const [progress, setProgress] = useState(0);
-
+  const [newPrompt, setNewPrompt] = useState<string>('');
+  const [commonPrompt, setCommonPrompt] = useState<string>('Anthropomorphic, human-like hands with five distinct fingers on each hand, fingers clearly separated (1-5)');
+  const [isGenerating, setIsGenerating] = useState<boolean>(false);
+  const [shouldStop, setShouldStop] = useState<boolean>(false);
   const [generatedImages, setGeneratedImages] = useState<GeneratedImage[]>([]);
-
-  /* モーダル */
+  const [progress, setProgress] = useState<number>(0);
+  const [selectMode, setSelectMode] = useState<boolean>(false);
   const [modalImageUrl, setModalImageUrl] = useState<string | null>(null);
+  const [fingerFixState, setFingerFixState] = useState<FingerFixState | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const shouldStopRef = useRef<boolean>(false);
+
+  /* モーダル操作 */
   const openModal = (url: string): void => setModalImageUrl(url);
   const closeModal = (): void => setModalImageUrl(null);
 
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-
-  /* ----- localStorage (プロンプト保存) ----- */
-  useEffect(() => {
-    const saved = localStorage.getItem('characterPosePrompts');
-    if (saved) setPosePrompts(JSON.parse(saved));
+  /* -------------------- localStorage -------------------- */
+  useEffect((): void => {
+      const savedPrompts = localStorage.getItem('characterPosePrompts');
+      if (savedPrompts) setPosePrompts(JSON.parse(savedPrompts));
+      
+      const savedCommonPrompt = localStorage.getItem('characterPoseCommonPrompt_2');
+      if (savedCommonPrompt) setCommonPrompt(savedCommonPrompt);
   }, []);
-  const savePrompts = (arr: string[]) =>
-    localStorage.setItem('characterPosePrompts', JSON.stringify(arr));
 
-  /* ----- 画像アップロード ----- */
-  const handleImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setSelectedImage(file);
-
-    const reader = new FileReader();
-    reader.onload = ev => {
-      if (typeof ev.target?.result === 'string') setImagePreview(ev.target.result);
-    };
-    reader.readAsDataURL(file);
+  const savePromptsToStorage = (prompts: string[]): void => {
+      localStorage.setItem('characterPosePrompts', JSON.stringify(prompts));
   };
 
-  /* ----- プロンプト操作 ----- */
-  const addPrompt = () => {
-    const t = newPrompt.trim();
-    if (t && !posePrompts.includes(t)) {
-      const next = [...posePrompts, t];
+  const saveCommonPromptToStorage = (commonPrompt: string): void => {
+      localStorage.setItem('characterPoseCommonPrompt_2', commonPrompt);
+  };
+
+  /* -------------------- utils -------------------- */
+  const handleImageUpload = (e: ChangeEvent<HTMLInputElement>): void => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      setSelectedImage(file);
+      const reader = new FileReader();
+      reader.onload = (ev): void => {
+          if (typeof ev.target?.result === 'string') setImagePreview(ev.target.result);
+      };
+      reader.readAsDataURL(file);
+  };
+
+  const addPrompt = (): void => {
+      const trimmed = newPrompt.trim();
+      if (trimmed && !posePrompts.includes(trimmed)) {
+          const next = [...posePrompts, trimmed];
+          setPosePrompts(next);
+          savePromptsToStorage(next);
+          setNewPrompt('');
+      }
+  };
+
+  const removePrompt = (idx: number): void => {
+      const next = posePrompts.filter((_, i) => i !== idx);
       setPosePrompts(next);
-      savePrompts(next);
-      setNewPrompt('');
-    }
-  };
-  const removePrompt = (idx: number) => {
-    const next = posePrompts.filter((_, i) => i !== idx);
-    setPosePrompts(next);
-    savePrompts(next);
+      savePromptsToStorage(next);
   };
 
-  /* ----- Base64 変換 ----- */
-  const toBase64 = (f: File) =>
-    new Promise<string>((ok, ng) => {
-      const r = new FileReader();
-      r.onload = () => (typeof r.result === 'string' ? ok(r.result) : ng());
-      r.onerror = () => ng(r.error ?? new Error('read error'));
-      r.readAsDataURL(f);
+  const convertImageToBase64 = (file: File): Promise<string> =>
+      new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => {
+              if (typeof reader.result === 'string') resolve(reader.result);
+              else reject(new Error('Base64 変換失敗'));
+          };
+          reader.onerror = () => reject(reader.error);
+          reader.readAsDataURL(file);
+      });
+
+    /** API Gateway 呼び出し */
+    const callAPI = async (prompt: string, imageB64: string): Promise<string> => {
+        try {
+            const response = await fetch('/api/characterPoseGeneration', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    prompt: `${commonPrompt}, ${prompt}`,
+                    negative_prompt: 'extra fingers, six fingers, fewer than five, fused/missing digits, deformed hands, paws, claws, hands cropped, occluded hands, blur',
+                    image_url: imageB64,
+                    seed: 42,
+                    steps: 30,
+                }),
+            });
+    
+            if (!response.ok) {
+                const errorText = await response.text();
+                throw new Error(`HTTP ${response.status}: ${errorText}`);
+            }
+    
+            const data = await response.json();
+            
+            // FAL APIの実際のレスポンス形式に対応
+            if (data.images && data.images[0] && data.images[0].url) {
+                return data.images[0].url;
+            }
+            
+            // エラーレスポンスの場合
+            if (data.error || data.detail) {
+                throw new Error(data.error || data.detail || '画像の取得に失敗しました');
+            }
+            
+            throw new Error('不明なレスポンス形式です');
+        } catch (err) {
+            console.error('API 呼び出しエラー:', err);
+            throw new Error('画像の生成中にエラーが発生しました');
+        }
+    };
+
+  /* -------------------- finger fix -------------------- */
+  const callFingerFixAPI = async (imageUrl: string): Promise<string[]> => {
+    const response = await fetch('/api/characterPoseGeneration', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt: FINGER_FIX_PROMPT,
+        negative_prompt: FINGER_FIX_NEGATIVE_PROMPT,
+        image_url: imageUrl,
+        strength: 0.45,
+        num_images: 3,
+      }),
     });
 
-  /* ----- FAL 呼び出し ----- */
-  const callFal = async (prompt: string, img64: string): Promise<string> => {
-    const fal = createFalClient({ credentials: apiKey });
-    const { data } = await fal.run('fal-ai/flux-pro/kontext', {
-      input: {
-        prompt: `${prompt} (make sure hands show five distinct fingers)`,
-        image_url: img64,
-        output_format: 'png',
-        guidance_scale: 9,
-        num_images: 1,
-        safety_tolerance: '6',
-        sync_mode: true,
-      },
-    });
-    return data.images[0].url;
-  };
-
-  /* ----- 生成 ----- */
-  const stopGeneration = () => {
-    shouldStopRef.current = true;
-  };
-
-  const generatePoseImages = async () => {
-    if (!selectedImage || posePrompts.length === 0) {
-      alert('画像とプロンプトを設定してください');
-      return;
-    }
-    if (!apiKey) {
-      alert('FAL.ai API キーを入力してください');
-      return;
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`HTTP ${response.status}: ${errorText}`);
     }
 
-    setIsGenerating(true);
-    shouldStopRef.current = false;
-    setProgress(0);
-    setGeneratedImages([]);
+    const data = await response.json();
+    if (data.images && data.images.length > 0) {
+      return data.images.map((img: { url: string }) => img.url);
+    }
+    throw new Error(data.error || data.detail || '指修正に失敗しました');
+  };
 
-    const img64 = await toBase64(selectedImage);
-    const results: GeneratedImage[] = [];
+  const startFingerFix = async (index: number): Promise<void> => {
+    const img = generatedImages.find(i => i.index === index);
+    if (!img || fingerFixState?.isLoading) return;
 
-    for (let i = 0; i < posePrompts.length; i++) {
-      if (shouldStopRef.current) break;
+    setFingerFixState({ targetIndex: index, candidates: [], isLoading: true, originalUrl: img.imageUrl });
 
-      const merged = `${commonPrompt} ${posePrompts[i]}`.trim();
-      try {
-        const url = await callFal(merged, img64);
-        results.push({ prompt: posePrompts[i], imageUrl: url, index: i, selected: true });
-      } catch {
-        results.push({
-          prompt: posePrompts[i],
-          imageUrl:
-            'data:image/svg+xml;base64,' +
-            btoa(
-              '<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512"><rect width="512" height="512" fill="#ffe6e6"/></svg>',
-            ),
-          index: i,
-          selected: true,
-        });
+    try {
+      const candidates = await callFingerFixAPI(img.imageUrl);
+      setFingerFixState({ targetIndex: index, candidates, isLoading: false, originalUrl: img.imageUrl });
+    } catch (err) {
+      console.error('指修正エラー:', err);
+      alert('指修正の候補生成に失敗しました');
+      setFingerFixState(null);
+    }
+  };
+
+  const applyFingerFix = (candidateUrl: string): void => {
+    if (!fingerFixState) return;
+    setGeneratedImages(prev =>
+      prev.map(i =>
+        i.index === fingerFixState.targetIndex ? { ...i, imageUrl: candidateUrl } : i,
+      ),
+    );
+    setFingerFixState(null);
+  };
+
+  const cancelFingerFix = (): void => setFingerFixState(null);
+
+  /* -------------------- generation -------------------- */
+  const stopGeneration = (): void => {
+      setShouldStop(true);
+      shouldStopRef.current = true;
+  };
+
+  const generatePoseImages = async (): Promise<void> => {
+      if ((!selectedImage && !designedCharacter) || posePrompts.length === 0) {
+          alert('画像とプロンプトを設定してください');
+          return;
       }
 
-      setProgress(((i + 1) / posePrompts.length) * 100);
-      setGeneratedImages([...results]);
+      setIsGenerating(true);
+      setShouldStop(false);
+      shouldStopRef.current = false;
+      setGeneratedImages([]);
+      setProgress(0);
 
-      if (!shouldStopRef.current) await new Promise(r => setTimeout(r, 300));
-    }
+      let imageRef: string;
+      if (designedCharacter) {
+          // designedCharacterのURLをそのまま使う（base64変換するとペイロード上限超過で503になる）
+          imageRef = designedCharacter.imageUrl;
+      } else {
+          imageRef = await convertImageToBase64(selectedImage!);
+      }
+      const results: GeneratedImage[] = [];
 
-    setIsGenerating(false);
-    shouldStopRef.current = false;
+      for (let i = 0; i < posePrompts.length; i++) {
+          if (shouldStopRef.current) break;
+          const prompt = posePrompts[i];
+
+          try {
+              const url = await callAPI(prompt, imageRef);
+              if (shouldStopRef.current) break;
+              results.push({ prompt, imageUrl: url, index: i, selected: false });
+          } catch {
+              if (shouldStopRef.current) break;
+              results.push({
+                  prompt,
+                  imageUrl:
+                      'data:image/svg+xml;base64,' +
+                      btoa(
+                          '<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512"><rect width="512" height="512" fill="#ffebee"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="16" fill="#c62828">Error</text></svg>',
+                      ),
+                  index: i,
+                  selected: false,
+              });
+          }
+
+          if (shouldStopRef.current) break;
+          setProgress(((i + 1) / posePrompts.length) * 100);
+          setGeneratedImages([...results]);
+          if (!shouldStopRef.current) await new Promise((r) => setTimeout(r, 300));
+      }
+
+      setIsGenerating(false);
+      setShouldStop(false);
+      shouldStopRef.current = false;
   };
 
-  /* ----- 選択 ----- */
-  const toggleImageSelection = (idx: number) =>
-    setGeneratedImages(prev =>
-      prev.map(img => (img.index === idx ? { ...img, selected: !img.selected } : img)),
-    );
-  const toggleSelectAll = () => {
-    const willSelect = !generatedImages.every(i => i.selected);
-    setGeneratedImages(prev => prev.map(i => ({ ...i, selected: willSelect })));
-  };
-  const selectedCount = generatedImages.filter(i => i.selected).length;
-
-  /* ----- DL (JSZip) ----- */
-  const makeZipAndSave = async (files: { name: string; blob: Blob }[], zipName: string) => {
-    const zip = new JSZip();
-    for (const f of files) {
-      // ArrayBuffer の方が互換性高い
-      zip.file(f.name, await f.blob.arrayBuffer());
-    }
-    const blob = await zip.generateAsync({ type: 'blob' });
-    saveAs(blob, zipName);
+  /* -------------------- selection -------------------- */
+  const toggleImageSelection = (idx: number): void => {
+      setGeneratedImages((prev): GeneratedImage[] =>
+          prev.map((img): GeneratedImage =>
+              img.index === idx ? { ...img, selected: !img.selected } : img,
+          ),
+      );
   };
 
-  const downloadSingleImage = async (img: GeneratedImage) => {
-    const blob = await (await fetch(img.imageUrl)).blob();
-    saveAs(blob, `pose_${img.index + 1}.png`);
+  const toggleSelectAll = (): void => {
+      const all = generatedImages.every((img) => img.selected);
+      setGeneratedImages((prev): GeneratedImage[] =>
+          prev.map((img): GeneratedImage => ({ ...img, selected: !all })),
+      );
   };
 
-  const downloadSelectedImages = async () => {
-    const targets = generatedImages.filter(i => i.selected);
-    if (targets.length === 0) return alert('画像を選択してください');
-
-    const files = await Promise.all(
-      targets.map(async img => ({
-        name: `pose_${img.index + 1}.png`,
-        blob: await (await fetch(img.imageUrl)).blob(),
-      })),
-    );
-    await makeZipAndSave(files, `poses_${targets.length}.zip`);
+  /* -------------------- download helpers -------------------- */
+  const downloadSingleBlob = (blob: Blob, filename: string): void => {
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(url);
   };
 
-  /* ====================================================== */
+  const downloadSingleImage = async (img: GeneratedImage): Promise<void> => {
+      const res = await fetch(img.imageUrl);
+      const blob = await res.blob();
+      downloadSingleBlob(blob, `pose_${img.index + 1}.png`);
+  };
+
+  const downloadSelectedImages = async (): Promise<void> => {
+      const targets = generatedImages.filter((img) => img.selected);
+      if (targets.length === 0) {
+          alert('画像を選択してください');
+          return;
+      }
+      
+      if (targets.length === 1) {
+          // 単一ファイルの場合は直接ダウンロード
+          const img = targets[0];
+          const res = await fetch(img.imageUrl);
+          const blob = await res.blob();
+          downloadSingleBlob(blob, `pose_${img.index + 1}.png`);
+      } else {
+          // 複数ファイルの場合はZIPで圧縮
+          const zip = new JSZip();
+          
+          for (const img of targets) {
+              const res = await fetch(img.imageUrl);
+              const blob = await res.blob();
+              zip.file(`pose_${img.index + 1}.png`, blob);
+          }
+          
+          const zipBlob = await zip.generateAsync({ type: 'blob' });
+          saveAs(zipBlob, `selected_${targets.length}.zip`);
+      }
+  };
+
+  const downloadAllImages = async (): Promise<void> => {
+      if (generatedImages.length === 0) {
+          alert('画像がありません');
+          return;
+      }
+      
+      if (generatedImages.length === 1) {
+          // 単一ファイルの場合は直接ダウンロード
+          const img = generatedImages[0];
+          const res = await fetch(img.imageUrl);
+          const blob = await res.blob();
+          downloadSingleBlob(blob, `pose_${img.index + 1}.png`);
+      } else {
+          // 複数ファイルの場合はZIPで圧縮
+          const zip = new JSZip();
+          
+          for (const img of generatedImages) {
+              const res = await fetch(img.imageUrl);
+              const blob = await res.blob();
+              zip.file(`pose_${img.index + 1}.png`, blob);
+          }
+          
+          const zipBlob = await zip.generateAsync({ type: 'blob' });
+          saveAs(zipBlob, 'all_poses.zip');
+      }
+  };
+
+  const selectedCount = generatedImages.filter((i) => i.selected).length;
+
+  /* -------------------- JSX -------------------- */
   return (
-    <>
-      {/* ---------- モーダル ---------- */}
-      {modalImageUrl && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={closeModal}
-        >
-          <div
-            className="relative bg-white p-4 rounded-lg shadow-lg max-w-[90vw] max-h-[90vh]"
-            onClick={e => e.stopPropagation()}
-          >
-            <button
-              onClick={closeModal}
-              className="absolute -right-3 -top-3 w-8 h-8 rounded-full bg-red-600 text-white flex items-center justify-center shadow"
-            >
-              ×
-            </button>
-            <img src={modalImageUrl} alt="preview" className="max-w-full max-h-[80vh]" />
-          </div>
-        </div>
-      )}
-
-      {/* ---------- UI ---------- */}
-      <div className="w-screen p-6 bg-gradient-to-br from-purple-50 to-pink-50 min-h-screen">
-        <div className="bg-white rounded-xl shadow-lg p-8 max-w-7xl mx-auto">
-          <h1 className="text-3xl font-bold text-center mb-8 text-purple-800">
-            <ImageIcon className="inline-block mr-3" />
-            キャラクターポーズ生成機能
-          </h1>
-
-          {/* =================== 1. API キー入力 =================== */}
-          <section className="mb-8 p-4 bg-blue-50 rounded-lg">
-            <header className="flex items-center mb-3">
-              <Settings className="mr-2 text-blue-600" />
-              <h2 className="text-lg font-semibold text-blue-800">API 設定</h2>
-            </header>
-            <input
-              type="password"
-              className="w-full p-3 border border-blue-200 rounded-lg"
-              placeholder="FAL.ai API キー"
-              value={apiKey}
-              onChange={e => setApiKey(e.target.value)}
-            />
-          </section>
-
-          {/* =================== 2. 画像アップロード =================== */}
-          <section className="mb-8 p-4 bg-green-50 rounded-lg">
-            <header className="flex items-center mb-3">
-              <Upload className="mr-2 text-green-600" />
-              <h2 className="text-lg font-semibold text-green-800">キャラクター画像</h2>
-            </header>
-            <div className="flex gap-4 flex-col md:flex-row">
-              <div className="flex-1">
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/*"
-                  onChange={handleImageUpload}
-                  className="hidden"
-                />
-                <button
-                  onClick={() => fileInputRef.current?.click()}
-                  className="w-full p-3 border-2 border-dashed border-green-300 rounded-lg hover:bg-green-100"
-                >
-                  画像をアップロード
-                </button>
-              </div>
-              {imagePreview && (
-                <img
-                  src={imagePreview}
-                  alt="preview"
-                  className="w-32 h-32 border-2 border-green-300 rounded object-cover"
-                />
-              )}
-            </div>
-          </section>
-
-          {/* =================== 3. 共通プロンプト =================== */}
-          <section className="mb-6">
-            <label className="block text-sm font-semibold mb-1 text-gray-700">
-              すべてのプロンプトに付与する共通語句
-            </label>
-            <input
-              value={commonPrompt}
-              onChange={e => setCommonPrompt(e.target.value)}
-              placeholder="例: high quality illustration, 8K"
-              className="w-full p-2 border border-gray-300 rounded"
-            />
-          </section>
-
-          {/* =================== 4. 個別プロンプト一覧 =================== */}
-          <section className="mb-8 p-4 bg-yellow-50 rounded-lg">
-            <h2 className="text-lg font-semibold text-yellow-800 mb-3">プロンプト</h2>
-
-            {/* 追加 */}
-            <div className="flex gap-2 mb-4">
-              <input
-                value={newPrompt}
-                onChange={e => setNewPrompt(e.target.value)}
-                onKeyDown={e => {
-                  if (e.key === 'Enter') addPrompt();
-                }}
-                placeholder="新しいポーズ"
-                className="flex-1 p-2 border border-yellow-300 rounded"
-              />
-              <button
-                onClick={addPrompt}
-                className="px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600"
+      <>
+          {/* ---------- モーダル ---------- */}
+          {modalImageUrl && (
+              <div
+                  className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+                  onClick={closeModal}
               >
-                <Plus size={16} />
-              </button>
-            </div>
+                  <div
+                      className="relative bg-white p-4 rounded-lg shadow-lg max-w-[90vw] max-h-[90vh]"
+                      onClick={(e) => e.stopPropagation()}
+                  >
+                      <button
+                          onClick={closeModal}
+                          className="absolute -right-3 -top-3 w-8 h-8 rounded-full bg-red-600 text-white flex items-center justify-center shadow"
+                      >
+                          ×
+                      </button>
+                      <img src={modalImageUrl} alt="preview" className="max-w-full max-h-[80vh]" />
+                  </div>
+              </div>
+          )}
 
-            {/* 一覧 */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-2 max-h-64 overflow-y-auto">
-              {posePrompts.map((p, i) => (
-                <div key={i} className="flex items-center gap-2 bg-white border rounded p-2">
-                  {editingIdx === i ? (
-                    <>
+          {/* ---------- 指修正モーダル ---------- */}
+          {fingerFixState && (
+              <div
+                  className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+                  onClick={cancelFingerFix}
+              >
+                  <div
+                      className="relative bg-white p-6 rounded-lg shadow-lg max-w-[90vw] max-h-[90vh] overflow-y-auto"
+                      onClick={(e) => e.stopPropagation()}
+                  >
+                      <button
+                          onClick={cancelFingerFix}
+                          className="absolute -right-3 -top-3 w-8 h-8 rounded-full bg-red-600 text-white flex items-center justify-center shadow"
+                      >
+                          ×
+                      </button>
+
+                      <h3 className="text-lg font-bold text-orange-800 mb-4">
+                          <Hand className="inline-block mr-2" size={20} />
+                          指修正 — 候補を選択してください
+                      </h3>
+
+                      {fingerFixState.isLoading ? (
+                          <div className="flex flex-col items-center justify-center py-16 px-8">
+                              <div className="animate-spin h-12 w-12 border-4 border-orange-500 border-t-transparent rounded-full mb-4" />
+                              <p className="text-gray-600">3パターンの候補を生成中...</p>
+                          </div>
+                      ) : (
+                          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                              <div className="border-2 border-gray-300 rounded-lg p-2">
+                                  <p className="text-xs text-center text-gray-500 mb-2 font-semibold">元画像</p>
+                                  <img
+                                      src={fingerFixState.originalUrl}
+                                      alt="original"
+                                      className="w-full h-auto rounded"
+                                  />
+                              </div>
+                              {fingerFixState.candidates.map((url, i) => (
+                                  <div
+                                      key={i}
+                                      onClick={() => applyFingerFix(url)}
+                                      className="border-2 border-orange-200 rounded-lg p-2 cursor-pointer hover:border-orange-500 hover:shadow-lg transition-all"
+                                  >
+                                      <p className="text-xs text-center text-orange-600 mb-2 font-semibold">
+                                          候補 {i + 1}
+                                      </p>
+                                      <img src={url} alt={`candidate ${i + 1}`} className="w-full h-auto rounded" />
+                                  </div>
+                              ))}
+                          </div>
+                      )}
+
+                      <div className="mt-4 text-center">
+                          <button
+                              onClick={cancelFingerFix}
+                              className="px-6 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300"
+                          >
+                              キャンセル
+                          </button>
+                      </div>
+                  </div>
+              </div>
+          )}
+
+          <div className="max-w-6xl mx-auto p-6 bg-gradient-to-br from-purple-50 to-pink-50 min-h-screen w-full">
+          <div className="bg-white rounded-xl shadow-lg p-8">
+              <h1 className="text-3xl font-bold text-center mb-8 text-purple-800">
+                  <ImageIcon className="inline-block mr-3" />
+                  キャラクターポーズ生成機能
+              </h1>
+
+
+              {/* ---------------- 画像入力 ---------------- */}
+              <section className="mb-8 p-4 bg-green-50 rounded-lg">
+                  <header className="flex items-center mb-3">
+                      <Upload className="mr-2 text-green-600" />
+                      <h2 className="text-lg font-semibold text-green-800">キャラクター画像</h2>
+                      {designedCharacter && (
+                          <span className="ml-auto text-sm text-green-600 bg-green-100 px-2 py-1 rounded">
+                              デザイナーから選択済み
+                          </span>
+                      )}
+                  </header>
+                  <div className="flex gap-4 flex-col md:flex-row">
+                      {!designedCharacter && (
+                          <div className="flex-1">
+                              <input
+                                  ref={fileInputRef}
+                                  type="file"
+                                  accept="image/*"
+                                  onChange={handleImageUpload}
+                                  className="hidden"
+                              />
+                              <button
+                                  onClick={(): void => fileInputRef.current?.click()}
+                                  className="w-full p-3 border-2 border-dashed border-green-300 rounded-lg hover:bg-green-100"
+                              >
+                                  画像をアップロード
+                              </button>
+                          </div>
+                      )}
+                      {designedCharacter && (
+                          <div className="flex-1">
+                              <div className="p-4 border border-green-300 rounded-lg bg-white">
+                                  <p className="text-sm text-gray-600">選択されたキャラクター画像を使用します</p>
+                              </div>
+                          </div>
+                      )}
+                      {imagePreview && (
+                          <img
+                              src={imagePreview}
+                              alt="preview"
+                              className="w-32 h-32 border-2 border-green-300 rounded object-cover"
+                          />
+                      )}
+                  </div>
+              </section>
+
+              {/* ---------------- 共通プロンプト ---------------- */}
+              <section className="mb-6">
+                  <label className="block text-sm font-semibold mb-1 text-gray-700">
+                      すべてのプロンプトに付与する共通語句
+                  </label>
+                  <input
+                      value={commonPrompt}
+                      onChange={(e): void => setCommonPrompt(e.target.value)}
+                      onBlur={(e): void => saveCommonPromptToStorage(e.target.value)}
+                      placeholder="例: high quality illustration, 8K"
+                      className="w-full p-2 border border-gray-300 rounded"
+                  />
+              </section>
+
+              {/* ---------------- プロンプト ---------------- */}
+              <section className="mb-8 p-4 bg-yellow-50 rounded-lg">
+                  <h2 className="text-lg font-semibold text-yellow-800 mb-3">プロンプト</h2>
+                  <div className="flex gap-2 mb-4">
                       <input
-                        autoFocus
-                        value={editingText}
-                        onChange={e => setEditingText(e.target.value)}
-                        onKeyDown={e => {
-                          if (e.key === 'Enter') {
-                            const next = [...posePrompts];
-                            next[i] = editingText.trim() || p;
-                            setPosePrompts(next);
-                            savePrompts(next);
-                            setEditingIdx(null);
-                          }
-                        }}
-                        className="flex-1 px-2 py-1 border rounded text-sm"
+                          value={newPrompt}
+                          onChange={(e): void => setNewPrompt(e.target.value)}
+                          onKeyDown={(e): void => {
+                              if (e.key === 'Enter') addPrompt();
+                          }}
+                          placeholder="新しいポーズ"
+                          className="flex-1 p-2 border border-yellow-300 rounded"
                       />
                       <button
-                        onClick={() => setEditingIdx(null)}
-                        className="text-gray-500 hover:text-gray-700 text-xs"
+                          onClick={addPrompt}
+                          className="px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600"
                       >
-                        キャンセル
+                          <Plus size={16} />
                       </button>
-                    </>
-                  ) : (
-                    <>
-                      <span
-                        onDoubleClick={() => {
-                          setEditingIdx(i);
-                          setEditingText(p);
-                        }}
-                        className="flex-1 text-sm cursor-text select-text"
-                      >
-                        {p}
-                      </span>
-                      <button
-                        onClick={() => removePrompt(i)}
-                        className="text-red-500 hover:text-red-700"
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    </>
-                  )}
-                </div>
-              ))}
-            </div>
-          </section>
-
-          {/* =================== 5. 生成／停止 =================== */}
-          <div className="mb-8 flex justify-center gap-4">
-            <button
-              onClick={generatePoseImages}
-              disabled={
-                isGenerating || !apiKey || !selectedImage || posePrompts.length === 0
-              }
-              className="px-8 py-3 bg-purple-600 text-white rounded-lg disabled:bg-gray-400 flex items-center"
-            >
-              {isGenerating ? (
-                <>
-                  <div className="animate-spin h-5 w-5 border-b-2 border-white mr-2" />
-                  生成中... {Math.round(progress)}%
-                </>
-              ) : (
-                <>
-                  <Play className="mr-2" size={20} /> 生成
-                </>
-              )}
-            </button>
-            {isGenerating && (
-              <button
-                onClick={stopGeneration}
-                className="px-6 py-3 bg-red-600 text-white rounded-lg flex items-center"
-              >
-                <Square className="mr-2" size={16} /> 停止
-              </button>
-            )}
-          </div>
-
-          {/* 進捗バー */}
-          {isGenerating && (
-            <div className="mb-8">
-              <div className="w-full bg-gray-200 h-2 rounded">
-                <div
-                  className="bg-purple-600 h-2 rounded"
-                  style={{ width: `${progress}%` }}
-                />
-              </div>
-              <p className="text-center text-sm text-gray-600 mt-2">
-                {Math.round(progress)}% 完了
-                {shouldStopRef.current && (
-                  <span className="ml-2 text-red-600">(停止中…)</span>
-                )}
-              </p>
-            </div>
-          )}
-
-          {/* =================== 6. 画像一覧 =================== */}
-          {generatedImages.length > 0 && (
-            <section className="mb-8">
-              <div className="flex flex-wrap gap-2 justify-between items-center mb-4">
-                <h2 className="text-lg font-semibold">
-                  生成画像 ({generatedImages.length})
-                </h2>
-                <div className="flex gap-2 flex-wrap items-center">
-                  <button
-                    onClick={toggleSelectAll}
-                    className="px-3 py-2 bg-gray-200 text-gray-700 rounded text-sm hover:bg-gray-300"
-                  >
-                    {generatedImages.every(i => i.selected) ? '全選択解除' : '全選択'}
-                  </button>
-                  <button
-                    onClick={downloadSelectedImages}
-                    disabled={selectedCount === 0}
-                    className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:bg-gray-400 flex items-center"
-                  >
-                    <Download className="mr-2" size={16} />
-                    一括ダウンロード&nbsp;({selectedCount})
-                  </button>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-                {generatedImages.map(img => (
-                  <div
-                    key={img.index}
-                    className="relative border rounded shadow-sm hover:shadow-md transition-all"
-                  >
-                    <img
-                      src={img.imageUrl}
-                      alt={img.prompt}
-                      className="w-full h-auto object-cover cursor-pointer"
-                      onClick={() => openModal(img.imageUrl)}
-                    />
-
-                    {/* チェック */}
-                    <div
-                      onClick={() => toggleImageSelection(img.index)}
-                      className={`absolute top-2 left-2 w-6 h-6 rounded-full border-2 flex items-center justify-center bg-white shadow-md cursor-pointer ${
-                        img.selected ? 'border-blue-500 bg-blue-100' : 'border-gray-400'
-                      }`}
-                    >
-                      {img.selected && <Check size={16} className="text-blue-600" />}
-                    </div>
-
-                    {/* 個別 DL */}
-                    <div className="p-2">
-                      <button
-                        onClick={() => downloadSingleImage(img)}
-                        className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 text-xs rounded py-1 flex items-center justify-center"
-                      >
-                        <Download className="mr-1" size={12} />
-                        DL
-                      </button>
-                    </div>
                   </div>
-                ))}
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-2 max-h-64 overflow-y-auto">
+                      {posePrompts.map((p, i) => (
+                          <div
+                              key={i}
+                              className="flex justify-between items-center p-2 bg-white rounded border"
+                          >
+                              <span className="text-sm">{p}</span>
+                              <button
+                                  onClick={(): void => removePrompt(i)}
+                                  className="text-red-500 hover:text-red-700"
+                              >
+                                  <Trash2 size={14} />
+                              </button>
+                          </div>
+                      ))}
+                  </div>
+              </section>
+
+              {/* ---------------- 生成／停止 ---------------- */}
+              <div className="mb-8 flex justify-center gap-4">
+                  <button
+                      onClick={generatePoseImages}
+                      disabled={
+                          isGenerating ||
+                          (!selectedImage && !designedCharacter) ||
+                          posePrompts.length === 0
+                      }
+                      className="px-8 py-3 bg-purple-600 text-white rounded-lg disabled:bg-gray-400 flex items-center"
+                  >
+                      {isGenerating ? (
+                          <>
+                              <div className="animate-spin h-5 w-5 border-b-2 border-white mr-2" />
+                              生成中... {Math.round(progress)}%
+                          </>
+                      ) : (
+                          <>
+                              <Play className="mr-2" size={20} /> 生成
+                          </>
+                      )}
+                  </button>
+                  {isGenerating && (
+                      <button
+                          onClick={stopGeneration}
+                          className="px-6 py-3 bg-red-600 text-white rounded-lg flex items-center"
+                      >
+                          <Square className="mr-2" size={16} /> 停止
+                      </button>
+                  )}
               </div>
-            </section>
-          )}
-        </div>
+
+              {/* ---------------- 進捗 ---------------- */}
+              {isGenerating && (
+                  <div className="mb-8">
+                      <div className="w-full bg-gray-200 h-2 rounded">
+                          <div
+                              className="bg-purple-600 h-2 rounded"
+                              style={{ width: `${progress}%` }}
+                          />
+                      </div>
+                      <p className="text-center text-sm text-gray-600 mt-2">
+                          {Math.round(progress)}% 完了
+                          {shouldStop && (
+                              <span className="ml-2 text-red-600">(停止中…)</span>
+                          )}
+                      </p>
+                  </div>
+              )}
+
+              {/* ---------------- 画像一覧 ---------------- */}
+              {generatedImages.length > 0 && (
+                  <section className="mb-8">
+                      <div className="flex flex-wrap gap-2 justify-between items-center mb-4">
+                          <h2 className="text-lg font-semibold">
+                              生成画像 ({generatedImages.length})
+                          </h2>
+                          <div className="flex gap-2 flex-wrap items-center">
+                              <button
+                                  onClick={(): void => setSelectMode(!selectMode)}
+                                  className={`px-3 py-2 rounded text-sm ${
+                                      selectMode
+                                          ? 'bg-blue-100 text-blue-700'
+                                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                                  }`}
+                              >
+                                  {selectMode ? '選択モード終了' : '選択モード'}
+                              </button>
+                              {selectMode && (
+                                  <>
+                                      <button
+                                          onClick={toggleSelectAll}
+                                          className="px-3 py-2 bg-gray-200 text-gray-700 rounded text-sm hover:bg-gray-300"
+                                      >
+                                          {generatedImages.every((i) => i.selected)
+                                              ? '全解除'
+                                              : '全選択'}
+                                      </button>
+                                      <button
+                                          onClick={(): void => void downloadSelectedImages()}
+                                          disabled={selectedCount === 0}
+                                          className="px-3 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:bg-gray-400 flex items-center"
+                                      >
+                                          <Download className="mr-1" size={14} />
+                                          {selectedCount === 1 ? '選択 DL' : `選択 ZIP (${selectedCount})`}
+                                      </button>
+                                  </>
+                              )}
+                              <button
+                                  onClick={(): void => void downloadAllImages()}
+                                  className="px-4 py-2 bg-green-600 text-white rounded text-sm hover:bg-green-700 flex items-center"
+                              >
+                                  <Download className="mr-2" size={16} /> 
+                                  {generatedImages.length === 1 ? '全 DL' : `全 ZIP (${generatedImages.length})`}
+                              </button>
+                          </div>
+                      </div>
+
+                      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                          {generatedImages.map((img) => (
+                              <div
+                                  key={img.index}
+                                  className={`border rounded shadow-sm hover:shadow-md relative ${
+                                      selectMode && img.selected ? 'ring-2 ring-blue-500' : ''
+                                  }`}
+                              >
+                                  {selectMode && (
+                                      <button
+                                          onClick={(): void => toggleImageSelection(img.index)}
+                                          className={`absolute top-2 left-2 w-6 h-6 rounded flex items-center justify-center shadow border-2 ${
+                                              img.selected 
+                                                  ? 'bg-blue-600 border-blue-600 text-white' 
+                                                  : 'bg-white border-gray-300 hover:border-blue-400'
+                                          }`}
+                                      >
+                                          {img.selected && (
+                                              <Check size={14} className="text-white" />
+                                          )}
+                                      </button>
+                                  )}
+
+                                  <img
+                                      src={img.imageUrl}
+                                      alt={img.prompt}
+                                      className="w-full h-48 object-contain cursor-pointer bg-gray-50"
+                                      onClick={(): void => {
+                                          if (selectMode) {
+                                              toggleImageSelection(img.index);
+                                          } else {
+                                              openModal(img.imageUrl);
+                                          }
+                                      }}
+                                  />
+                                  <div className="p-2">
+                                      <p
+                                          className="text-xs text-gray-600 truncate mb-1"
+                                          title={img.prompt}
+                                      >
+                                          {img.prompt}
+                                      </p>
+                                      <div className="flex gap-1">
+                                          <button
+                                              onClick={(): void => {
+                                                  if (onOpenFingerFix) {
+                                                      onOpenFingerFix(img.imageUrl);
+                                                  } else {
+                                                      void startFingerFix(img.index);
+                                                  }
+                                              }}
+                                              disabled={fingerFixState?.isLoading}
+                                              className="flex-1 bg-orange-100 hover:bg-orange-200 text-orange-700 text-xs rounded py-1 flex items-center justify-center disabled:opacity-50"
+                                          >
+                                              <Hand className="mr-1" size={12} />
+                                              指修正
+                                          </button>
+                                          <button
+                                              onClick={(): void => void downloadSingleImage(img)}
+                                              className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-700 text-xs rounded py-1 flex items-center justify-center"
+                                          >
+                                              <Download className="mr-1" size={12} />
+                                              DL
+                                          </button>
+                                      </div>
+                                  </div>
+                              </div>
+                          ))}
+                      </div>
+                  </section>
+              )}
+          </div>
       </div>
-    </>
+      </>
   );
 };
 

--- a/create_characters/character-pose/src/components/FingerFixTab.tsx
+++ b/create_characters/character-pose/src/components/FingerFixTab.tsx
@@ -1,0 +1,843 @@
+/**
+ * 指修正タブコンポーネント
+ * 画像アップロード → 複数範囲選択 → スケッチ補助 → 複数モデルで指修正
+ */
+
+import { useState, useRef, useCallback, useEffect, type ChangeEvent, type JSX } from 'react';
+import { Upload, Hand, Download, RotateCcw, Settings, Pencil, Eraser } from 'lucide-react';
+import { createFalClient } from '@fal-ai/client';
+
+/* ---------- 定数 ---------- */
+const DEFAULT_PROMPT =
+  'Edit only the fingers in the masked area to show exactly five fingers (thumb, index, middle, ring, pinky). Keep the same pose, same art style, same colors, and same objects. Do not change anything outside the masked area.';
+
+type ModelId = 'gpt-image' | 'flux2-pro' | 'flux-fill' | 'nano-banana-pro';
+
+interface ModelOption {
+  id: ModelId;
+  name: string;
+  description: string;
+  needsMask: boolean;
+  hasStrength: boolean;
+}
+
+const MODELS: ModelOption[] = [
+  { id: 'gpt-image', name: 'GPT Image 1.5 Edit', description: 'マスクベース精密編集（推奨）', needsMask: true, hasStrength: false },
+  { id: 'flux2-pro', name: 'FLUX.2 Pro Edit', description: '最新・プロンプトベース編集', needsMask: false, hasStrength: false },
+  { id: 'flux-fill', name: 'FLUX.1 Fill', description: 'マスクベースインペインティング', needsMask: true, hasStrength: true },
+  { id: 'nano-banana-pro', name: 'Nano Banana Pro', description: 'Gemini テキスト指示ベース', needsMask: false, hasStrength: false },
+];
+
+const BRUSH_COLORS = ['#ff0000', '#0000ff', '#00aa00', '#ffffff', '#000000', '#ff8800'];
+
+/* ---------- 型 ---------- */
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+interface StrokePoint {
+  x: number;
+  y: number;
+}
+
+interface Stroke {
+  points: StrokePoint[];
+  color: string;
+  width: number;
+  isEraser: boolean;
+}
+
+/** 複数Rectのバウンディングボックスを返す */
+const getBoundingBox = (rects: Rect[]): Rect | null => {
+  if (rects.length === 0) return null;
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (const r of rects) {
+    minX = Math.min(minX, r.x);
+    minY = Math.min(minY, r.y);
+    maxX = Math.max(maxX, r.x + r.w);
+    maxY = Math.max(maxY, r.y + r.h);
+  }
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+};
+
+interface FingerFixTabProps {
+  initialImageUrl?: string | null;
+  onImageConsumed?: () => void;
+}
+
+const FingerFixTab = ({ initialImageUrl, onImageConsumed }: FingerFixTabProps = {}): JSX.Element => {
+  /* ----- state ----- */
+  const [apiKey, setApiKey] = useState('');
+  const [selectedModel, setSelectedModel] = useState<ModelId>('gpt-image');
+  const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
+  const [strength, setStrength] = useState(0.3);
+  const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
+  const [imageEl, setImageEl] = useState<HTMLImageElement | null>(null);
+  const [selections, setSelections] = useState<Rect[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragStart, setDragStart] = useState<{ x: number; y: number } | null>(null);
+  const [pendingRect, setPendingRect] = useState<Rect | null>(null);
+
+  const [isFixing, setIsFixing] = useState(false);
+  const [candidates, setCandidates] = useState<string[]>([]);
+  const [resultImageUrl, setResultImageUrl] = useState<string | null>(null);
+
+  const [croppedOriginal, setCroppedOriginal] = useState<string | null>(null);
+  const [croppedCandidates, setCroppedCandidates] = useState<string[]>([]);
+
+  /* ----- スケッチ state ----- */
+  const [sketchMode, setSketchMode] = useState(false);
+  const [brushColor, setBrushColor] = useState('#ff0000');
+  const [brushSize, setBrushSize] = useState(10);
+  const [isEraser, setIsEraser] = useState(false);
+  const [strokes, setStrokes] = useState<Stroke[]>([]);
+  const [currentStroke, setCurrentStroke] = useState<Stroke | null>(null);
+  const [isDrawing, setIsDrawing] = useState(false);
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const currentModel = MODELS.find(m => m.id === selectedModel)!;
+
+  /* ----- 外部から画像を受け取る ----- */
+  useEffect(() => {
+    if (!initialImageUrl) return;
+    const loadExternalImage = async () => {
+      try {
+        // URLから画像をfetch→dataURLに変換
+        const res = await fetch(initialImageUrl);
+        const blob = await res.blob();
+        const reader = new FileReader();
+        reader.onload = (ev) => {
+          const dataUrl = ev.target?.result as string;
+          setImageDataUrl(dataUrl);
+          setSelections([]);
+          setCandidates([]);
+          setCroppedCandidates([]);
+          setCroppedOriginal(null);
+          setResultImageUrl(null);
+          setSketchMode(false);
+          setStrokes([]);
+          const img = new Image();
+          img.onload = () => setImageEl(img);
+          img.src = dataUrl;
+        };
+        reader.readAsDataURL(blob);
+      } catch {
+        // fallback: URLをそのまま使う
+        setImageDataUrl(initialImageUrl);
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.onload = () => setImageEl(img);
+        img.src = initialImageUrl;
+      }
+      onImageConsumed?.();
+    };
+    void loadExternalImage();
+  }, [initialImageUrl]);
+
+  /* ----- 画像アップロード ----- */
+  const handleImageUpload = (e: ChangeEvent<HTMLInputElement>): void => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const dataUrl = ev.target?.result as string;
+      setImageDataUrl(dataUrl);
+      setSelections([]);
+      setCandidates([]);
+      setCroppedCandidates([]);
+      setCroppedOriginal(null);
+      setResultImageUrl(null);
+      setSketchMode(false);
+      setStrokes([]);
+
+      const img = new Image();
+      img.onload = () => setImageEl(img);
+      img.src = dataUrl;
+    };
+    reader.readAsDataURL(file);
+  };
+
+  /* ----- ストローク描画ヘルパー ----- */
+  const drawStroke = (ctx: CanvasRenderingContext2D, stroke: Stroke) => {
+    if (stroke.points.length < 2) return;
+    ctx.save();
+    if (stroke.isEraser) {
+      ctx.globalCompositeOperation = 'destination-out';
+    }
+    ctx.strokeStyle = stroke.color;
+    ctx.lineWidth = stroke.width;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    ctx.moveTo(stroke.points[0].x, stroke.points[0].y);
+    for (let i = 1; i < stroke.points.length; i++) {
+      ctx.lineTo(stroke.points[i].x, stroke.points[i].y);
+    }
+    ctx.stroke();
+    ctx.restore();
+  };
+
+  /* ----- Canvas描画 ----- */
+  const drawCanvas = useCallback(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+    if (!canvas || !ctx || !imageEl) return;
+
+    canvas.width = imageEl.naturalWidth;
+    canvas.height = imageEl.naturalHeight;
+    ctx.drawImage(imageEl, 0, 0);
+
+    const allRects = pendingRect ? [...selections, pendingRect] : selections;
+
+    if (allRects.length > 0) {
+      // 暗くする（選択範囲外）
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      // 各選択範囲を明るく
+      for (const sel of allRects) {
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(sel.x, sel.y, sel.w, sel.h);
+        ctx.clip();
+        ctx.drawImage(imageEl, 0, 0);
+        ctx.restore();
+      }
+
+      // スケッチを描画（全選択範囲内にクリップ）
+      if (strokes.length > 0 || currentStroke) {
+        ctx.save();
+        ctx.beginPath();
+        for (const sel of allRects) {
+          ctx.rect(sel.x, sel.y, sel.w, sel.h);
+        }
+        ctx.clip();
+        for (const s of strokes) drawStroke(ctx, s);
+        if (currentStroke) drawStroke(ctx, currentStroke);
+        ctx.restore();
+      }
+
+      // 選択枠
+      for (const sel of allRects) {
+        ctx.strokeStyle = sketchMode ? '#3b82f6' : '#f97316';
+        ctx.lineWidth = 3;
+        ctx.setLineDash([8, 4]);
+        ctx.strokeRect(sel.x, sel.y, sel.w, sel.h);
+        ctx.setLineDash([]);
+      }
+    }
+  }, [imageEl, selections, pendingRect, strokes, currentStroke, sketchMode]);
+
+  useEffect(() => { drawCanvas(); }, [drawCanvas]);
+
+  /* ----- マウスイベント ----- */
+  const getCanvasCoords = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current!;
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: (e.clientX - rect.left) * (canvas.width / rect.width),
+      y: (e.clientY - rect.top) * (canvas.height / rect.height),
+    };
+  };
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>): void => {
+    const coords = getCanvasCoords(e);
+
+    if (sketchMode && selections.length > 0) {
+      // スケッチモード: 描画開始
+      setIsDrawing(true);
+      setCurrentStroke({
+        points: [coords],
+        color: isEraser ? '#ffffff' : brushColor,
+        width: brushSize,
+        isEraser,
+      });
+      return;
+    }
+
+    // 範囲選択モード: 新しい矩形を追加
+    setDragStart(coords);
+    setIsDragging(true);
+    setPendingRect(null);
+    setCandidates([]);
+    setCroppedCandidates([]);
+    setCroppedOriginal(null);
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>): void => {
+    const coords = getCanvasCoords(e);
+
+    if (sketchMode && isDrawing && currentStroke) {
+      setCurrentStroke({
+        ...currentStroke,
+        points: [...currentStroke.points, coords],
+      });
+      return;
+    }
+
+    if (!isDragging || !dragStart) return;
+    setPendingRect({
+      x: Math.min(dragStart.x, coords.x),
+      y: Math.min(dragStart.y, coords.y),
+      w: Math.abs(coords.x - dragStart.x),
+      h: Math.abs(coords.y - dragStart.y),
+    });
+  };
+
+  const handleMouseUp = (): void => {
+    if (sketchMode && isDrawing && currentStroke) {
+      if (currentStroke.points.length >= 2) {
+        setStrokes(prev => [...prev, currentStroke]);
+      }
+      setCurrentStroke(null);
+      setIsDrawing(false);
+      return;
+    }
+
+    setIsDragging(false);
+    setDragStart(null);
+    if (pendingRect && pendingRect.w >= 20 && pendingRect.h >= 20) {
+      setSelections(prev => [...prev, pendingRect]);
+    }
+    setPendingRect(null);
+  };
+
+  /* ----- マスク生成（白黒: 黒=保持、白=編集） ----- */
+  const generateMaskDataUrl = (): string | null => {
+    if (!imageEl || selections.length === 0) return null;
+    const c = document.createElement('canvas');
+    c.width = imageEl.naturalWidth;
+    c.height = imageEl.naturalHeight;
+    const ctx = c.getContext('2d')!;
+    ctx.fillStyle = '#000000';
+    ctx.fillRect(0, 0, c.width, c.height);
+    ctx.fillStyle = '#ffffff';
+    for (const sel of selections) {
+      ctx.fillRect(sel.x, sel.y, sel.w, sel.h);
+    }
+    return c.toDataURL('image/png');
+  };
+
+  /* ----- GPT Image用: 選択範囲を透明にした元画像 ----- */
+  const generateErasedImageDataUrl = (): string => {
+    if (!imageEl || selections.length === 0) return imageDataUrl!;
+    const c = document.createElement('canvas');
+    c.width = imageEl.naturalWidth;
+    c.height = imageEl.naturalHeight;
+    const ctx = c.getContext('2d')!;
+    ctx.drawImage(imageEl, 0, 0);
+    // 選択範囲を透明に（ここをAIが生成する）
+    for (const sel of selections) {
+      ctx.clearRect(sel.x, sel.y, sel.w, sel.h);
+    }
+    return c.toDataURL('image/png');
+  };
+
+  /* ----- スケッチ入り画像を生成 ----- */
+  const generateSketchedImageDataUrl = (): string => {
+    if (!imageEl || strokes.length === 0) return imageDataUrl!;
+    const c = document.createElement('canvas');
+    c.width = imageEl.naturalWidth;
+    c.height = imageEl.naturalHeight;
+    const ctx = c.getContext('2d')!;
+    ctx.drawImage(imageEl, 0, 0);
+    for (const s of strokes) drawStroke(ctx, s);
+    return c.toDataURL('image/png');
+  };
+
+  /* ----- クローズアップ（CORS回避: fetchでblob取得） ----- */
+  const cropImage = async (sourceUrl: string, sel: Rect): Promise<string> => {
+    try {
+      let objectUrl: string | null = null;
+      let imgSrc = sourceUrl;
+      if (sourceUrl.startsWith('http')) {
+        const res = await fetch(sourceUrl);
+        const blob = await res.blob();
+        objectUrl = URL.createObjectURL(blob);
+        imgSrc = objectUrl;
+      }
+      return await new Promise<string>((resolve) => {
+        const img = new Image();
+        img.onload = () => {
+          const c = document.createElement('canvas');
+          c.width = sel.w;
+          c.height = sel.h;
+          c.getContext('2d')!.drawImage(img, sel.x, sel.y, sel.w, sel.h, 0, 0, sel.w, sel.h);
+          if (objectUrl) URL.revokeObjectURL(objectUrl);
+          resolve(c.toDataURL('image/png'));
+        };
+        img.onerror = () => {
+          if (objectUrl) URL.revokeObjectURL(objectUrl);
+          resolve(sourceUrl);
+        };
+        img.src = imgSrc;
+      });
+    } catch {
+      return sourceUrl;
+    }
+  };
+
+  /* ----- API呼び出し ----- */
+  const startFingerFix = async (): Promise<void> => {
+    if (!imageDataUrl) return;
+    if (!apiKey) { alert('FAL.ai API キーを入力してください'); return; }
+    if (currentModel.needsMask && selections.length === 0) { alert('修正範囲を選択してください'); return; }
+
+    setIsFixing(true);
+    setCandidates([]);
+    setCroppedCandidates([]);
+    setCroppedOriginal(null);
+
+    const maskDataUrl = generateMaskDataUrl();
+    const erasedImageDataUrl = generateErasedImageDataUrl();
+    const sketchedImageDataUrl = generateSketchedImageDataUrl();
+    const hasSketch = strokes.length > 0;
+
+    try {
+      const fal = createFalClient({ credentials: apiKey });
+
+      const callApi = (): Promise<{ data: { images: { url: string }[] } }> => {
+        switch (selectedModel) {
+          case 'gpt-image':
+            // OpenAI方式: 元画像の選択範囲を透明にして送信（透明部分をAIが生成）
+            return fal.run('fal-ai/gpt-image-1.5/edit' as any, {
+              input: {
+                prompt: hasSketch
+                  ? `${prompt} Use the rough sketch drawn on the second reference image as a guide for finger placement and count.`
+                  : prompt,
+                image_urls: hasSketch
+                  ? [erasedImageDataUrl, sketchedImageDataUrl]
+                  : [erasedImageDataUrl],
+                quality: 'high',
+                num_images: 1,
+                background: 'opaque',
+                input_fidelity: 'high',
+              } as any,
+            }) as any;
+
+          case 'flux2-pro':
+            return fal.run('fal-ai/flux-2-pro/edit' as any, {
+              input: {
+                prompt: hasSketch
+                  ? `${prompt} Use the rough sketch as a guide for finger placement and count.`
+                  : prompt,
+                image_urls: hasSketch
+                  ? [sketchedImageDataUrl]
+                  : [imageDataUrl],
+                safety_tolerance: '5',
+                sync_mode: true,
+              } as any,
+            }) as any;
+
+          case 'flux-fill':
+            return fal.run('fal-ai/flux-pro/v1/fill' as any, {
+              input: {
+                prompt: hasSketch
+                  ? `${prompt} Follow the rough sketch guide for finger placement.`
+                  : prompt,
+                image_url: hasSketch ? sketchedImageDataUrl : imageDataUrl,
+                mask_url: maskDataUrl,
+                strength,
+                num_images: 1,
+                safety_tolerance: '6',
+                sync_mode: true,
+              } as any,
+            }) as any;
+
+          case 'nano-banana-pro':
+            return fal.run('fal-ai/nano-banana-pro/edit' as any, {
+              input: {
+                prompt: hasSketch
+                  ? `${prompt} Follow the rough sketch guide for finger placement.`
+                  : prompt,
+                image_urls: hasSketch
+                  ? [sketchedImageDataUrl]
+                  : [imageDataUrl],
+                num_images: 1,
+              } as any,
+            }) as any;
+        }
+      };
+
+      const results = await Promise.all([callApi(), callApi(), callApi()]);
+      const urls = results.map((r) => r.data.images[0].url);
+      setCandidates(urls);
+
+      const bbox = getBoundingBox(selections);
+      if (bbox) {
+        setCroppedOriginal(await cropImage(imageDataUrl, bbox));
+        setCroppedCandidates(await Promise.all(urls.map(url => cropImage(url, bbox))));
+      }
+    } catch (err) {
+      console.error('指修正エラー:', err);
+      alert(`指修正に失敗しました: ${err}`);
+    } finally {
+      setIsFixing(false);
+    }
+  };
+
+  /* ----- 候補選択 ----- */
+  const applyCandidate = (url: string): void => {
+    setResultImageUrl(url);
+    setCandidates([]);
+    setCroppedCandidates([]);
+    setCroppedOriginal(null);
+    setSelections([]);
+    setSketchMode(false);
+    setStrokes([]);
+  };
+
+  const useResultAsSource = (): void => {
+    if (!resultImageUrl) return;
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => {
+      setImageEl(img);
+      const c = document.createElement('canvas');
+      c.width = img.naturalWidth;
+      c.height = img.naturalHeight;
+      c.getContext('2d')!.drawImage(img, 0, 0);
+      setImageDataUrl(c.toDataURL('image/png'));
+      setResultImageUrl(null);
+      setSelections([]);
+      setStrokes([]);
+    };
+    img.src = resultImageUrl;
+  };
+
+  const downloadResult = async (): Promise<void> => {
+    const url = resultImageUrl || imageDataUrl;
+    if (!url) return;
+    const blob = await (await fetch(url)).blob();
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'finger_fixed.png';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  };
+
+  const resetSelections = (): void => {
+    setSelections([]);
+    setPendingRect(null);
+    setCandidates([]);
+    setCroppedCandidates([]);
+    setCroppedOriginal(null);
+    setSketchMode(false);
+    setStrokes([]);
+  };
+
+  const removeLastSelection = (): void => {
+    setSelections(prev => prev.slice(0, -1));
+  };
+
+  const undoStroke = (): void => {
+    setStrokes(prev => prev.slice(0, -1));
+  };
+
+  /* ====================================================== */
+  return (
+    <div className="p-6">
+      <div className="bg-white rounded-xl shadow-lg p-8">
+        <h1 className="text-3xl font-bold text-center mb-8 text-orange-800">
+          <Hand className="inline-block mr-3" />
+          指修正ツール
+        </h1>
+
+        {/* -------- API設定 -------- */}
+        <section className="mb-8 p-4 bg-blue-50 rounded-lg">
+          <header className="flex items-center mb-3">
+            <Settings className="mr-2 text-blue-600" />
+            <h2 className="text-lg font-semibold text-blue-800">API 設定</h2>
+          </header>
+          <input
+            type="password"
+            className="w-full p-3 border border-blue-200 rounded-lg mb-3"
+            placeholder="FAL.ai API キー"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+          />
+
+          <label className="block text-sm font-semibold text-gray-700 mb-1">モデル</label>
+          <select
+            value={selectedModel}
+            onChange={(e) => setSelectedModel(e.target.value as ModelId)}
+            className="w-full p-3 border border-blue-200 rounded-lg bg-white"
+          >
+            {MODELS.map(m => (
+              <option key={m.id} value={m.id}>
+                {m.name} — {m.description}
+              </option>
+            ))}
+          </select>
+        </section>
+
+        {/* -------- 修正設定 -------- */}
+        <section className="mb-8 p-4 bg-orange-50 rounded-lg">
+          <header className="flex items-center mb-3">
+            <Hand className="mr-2 text-orange-600" />
+            <h2 className="text-lg font-semibold text-orange-800">修正設定</h2>
+          </header>
+
+          <label className="block text-sm font-semibold text-gray-700 mb-1">プロンプト</label>
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            rows={3}
+            className="w-full p-3 border border-orange-200 rounded text-sm mb-3"
+          />
+
+          {currentModel.hasStrength && (
+            <>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">
+                Strength: {strength.toFixed(2)}
+                <span className="font-normal text-gray-500 ml-2">（低い＝元画像を保持）</span>
+              </label>
+              <input
+                type="range" min="0.1" max="0.8" step="0.05"
+                value={strength}
+                onChange={(e) => setStrength(parseFloat(e.target.value))}
+                className="w-full"
+              />
+              <div className="flex justify-between text-xs text-gray-400 mt-1">
+                <span>0.1（微修正）</span>
+                <span>0.8（大幅変更）</span>
+              </div>
+            </>
+          )}
+        </section>
+
+        {/* -------- 画像アップロード -------- */}
+        <section className="mb-8 p-4 bg-green-50 rounded-lg">
+          <header className="flex items-center mb-3">
+            <Upload className="mr-2 text-green-600" />
+            <h2 className="text-lg font-semibold text-green-800">画像アップロード</h2>
+          </header>
+          <input ref={fileInputRef} type="file" accept="image/*" onChange={handleImageUpload} className="hidden" />
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            className="w-full p-3 border-2 border-dashed border-green-300 rounded-lg hover:bg-green-100"
+          >
+            画像を選択
+          </button>
+        </section>
+
+        {/* -------- Canvas -------- */}
+        {imageEl && (
+          <section className="mb-8">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-lg font-semibold text-gray-800">
+                {sketchMode
+                  ? '選択範囲にスケッチを描いてください（指の位置をガイド）'
+                  : currentModel.needsMask
+                    ? '修正範囲をドラッグで選択（複数可）'
+                    : 'クローズアップ表示する範囲を選択（複数可・任意）'}
+              </h2>
+              <div className="flex gap-2">
+                {selections.length > 0 && !sketchMode && (
+                  <button
+                    onClick={() => setSketchMode(true)}
+                    className="px-3 py-2 bg-blue-500 text-white rounded text-sm hover:bg-blue-600 flex items-center"
+                  >
+                    <Pencil className="mr-1" size={14} /> スケッチ補助
+                  </button>
+                )}
+                {selections.length > 1 && !sketchMode && (
+                  <button onClick={removeLastSelection} className="px-3 py-2 bg-yellow-100 text-yellow-700 rounded text-sm hover:bg-yellow-200 flex items-center">
+                    <RotateCcw className="mr-1" size={14} /> 最後の選択を取消
+                  </button>
+                )}
+                {selections.length > 0 && (
+                  <button onClick={resetSelections} className="px-3 py-2 bg-gray-200 text-gray-700 rounded text-sm hover:bg-gray-300 flex items-center">
+                    <RotateCcw className="mr-1" size={14} /> 全リセット
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* スケッチツールバー */}
+            {sketchMode && selections.length > 0 && (
+              <div className="mb-3 p-3 bg-blue-50 rounded-lg flex flex-wrap items-center gap-4">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold text-blue-700">ツール:</span>
+                  <button
+                    onClick={() => setIsEraser(false)}
+                    className={`px-3 py-1.5 rounded text-sm flex items-center ${!isEraser ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 border'}`}
+                  >
+                    <Pencil size={14} className="mr-1" /> ペン
+                  </button>
+                  <button
+                    onClick={() => setIsEraser(true)}
+                    className={`px-3 py-1.5 rounded text-sm flex items-center ${isEraser ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 border'}`}
+                  >
+                    <Eraser size={14} className="mr-1" /> 消しゴム
+                  </button>
+                </div>
+
+                {!isEraser && (
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-semibold text-blue-700">色:</span>
+                    {BRUSH_COLORS.map(c => (
+                      <button
+                        key={c}
+                        onClick={() => setBrushColor(c)}
+                        className={`w-7 h-7 rounded-full border-2 ${brushColor === c ? 'border-blue-600 scale-110' : 'border-gray-300'}`}
+                        style={{ backgroundColor: c }}
+                      />
+                    ))}
+                    <input
+                      type="color"
+                      value={brushColor}
+                      onChange={(e) => setBrushColor(e.target.value)}
+                      className="w-8 h-8 rounded cursor-pointer border border-gray-300"
+                      title="自由に色を選択"
+                    />
+                  </div>
+                )}
+
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold text-blue-700">太さ:</span>
+                  <input
+                    type="range" min="10" max="100" step="10" value={brushSize}
+                    onChange={(e) => setBrushSize(parseInt(e.target.value))}
+                    className="w-24"
+                  />
+                  <span className="text-xs text-gray-500">{brushSize}px</span>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={undoStroke}
+                    disabled={strokes.length === 0}
+                    className="px-3 py-1.5 bg-white text-gray-600 border rounded text-sm hover:bg-gray-50 disabled:opacity-40 flex items-center"
+                  >
+                    <RotateCcw size={14} className="mr-1" /> 戻す
+                  </button>
+                  <button
+                    onClick={() => setStrokes([])}
+                    disabled={strokes.length === 0}
+                    className="px-3 py-1.5 bg-white text-gray-600 border rounded text-sm hover:bg-gray-50 disabled:opacity-40"
+                  >
+                    全消去
+                  </button>
+                  <button
+                    onClick={() => setSketchMode(false)}
+                    className="px-3 py-1.5 bg-gray-200 text-gray-700 rounded text-sm hover:bg-gray-300"
+                  >
+                    選択モードに戻る
+                  </button>
+                </div>
+
+                {strokes.length > 0 && (
+                  <span className="text-xs text-green-600 font-semibold">
+                    スケッチ {strokes.length} ストローク（AI の参考画像として送信されます）
+                  </span>
+                )}
+              </div>
+            )}
+
+            <div className="border-2 border-gray-300 rounded-lg overflow-hidden inline-block">
+              <canvas
+                ref={canvasRef}
+                className="max-w-full h-auto cursor-crosshair"
+                style={{ maxHeight: '600px' }}
+                onMouseDown={handleMouseDown}
+                onMouseMove={handleMouseMove}
+                onMouseUp={handleMouseUp}
+                onMouseLeave={handleMouseUp}
+              />
+            </div>
+            {selections.length > 0 && (
+              <p className="text-sm text-gray-500 mt-2">
+                選択範囲: {selections.length} 箇所
+                {strokes.length > 0 && <span className="ml-3 text-blue-600">+ スケッチ補助あり</span>}
+              </p>
+            )}
+          </section>
+        )}
+
+        {/* -------- 修正ボタン -------- */}
+        {imageEl && (!currentModel.needsMask || selections.length > 0) && (
+          <div className="mb-8 flex justify-center">
+            <button
+              onClick={() => void startFingerFix()}
+              disabled={isFixing || !apiKey}
+              className="px-8 py-3 bg-orange-600 text-white rounded-lg disabled:bg-gray-400 flex items-center text-lg"
+            >
+              {isFixing ? (
+                <><div className="animate-spin h-5 w-5 border-b-2 border-white mr-3" /> 3候補を生成中...</>
+              ) : (
+                <><Hand className="mr-3" size={20} /> 指を修正（3候補生成）</>
+              )}
+            </button>
+          </div>
+        )}
+
+        {/* -------- 候補表示 -------- */}
+        {candidates.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-lg font-semibold text-orange-800 mb-4">候補を選択してください</h2>
+
+            {croppedOriginal && croppedCandidates.length > 0 && (
+              <>
+                <h3 className="text-sm font-semibold text-gray-600 mb-3">クローズアップ</h3>
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+                  <div className="border-2 border-gray-300 rounded-lg p-3">
+                    <p className="text-xs text-center text-gray-500 mb-2 font-semibold">元画像</p>
+                    <img src={croppedOriginal} alt="original" className="w-full h-auto rounded" />
+                  </div>
+                  {croppedCandidates.map((cropUrl, i) => (
+                    <div key={i} onClick={() => applyCandidate(candidates[i])}
+                      className="border-2 border-orange-200 rounded-lg p-3 cursor-pointer hover:border-orange-500 hover:shadow-lg transition-all">
+                      <p className="text-xs text-center text-orange-600 mb-2 font-semibold">候補 {i + 1}</p>
+                      <img src={cropUrl} alt={`candidate ${i + 1}`} className="w-full h-auto rounded" />
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+
+            <h3 className="text-sm font-semibold text-gray-600 mb-3">全体画像</h3>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {candidates.map((url, i) => (
+                <div key={i} onClick={() => applyCandidate(url)}
+                  className="border-2 border-orange-200 rounded-lg p-3 cursor-pointer hover:border-orange-500 hover:shadow-lg transition-all">
+                  <p className="text-xs text-center text-orange-600 mb-2 font-semibold">候補 {i + 1}</p>
+                  <img src={url} alt={`candidate ${i + 1}`} className="w-full h-auto rounded" />
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-4 text-center">
+              <button onClick={resetSelections} className="px-6 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300">キャンセル</button>
+            </div>
+          </section>
+        )}
+
+        {/* -------- 結果表示 -------- */}
+        {resultImageUrl && (
+          <section className="mb-8">
+            <h2 className="text-lg font-semibold text-green-800 mb-4">修正結果</h2>
+            <div className="border-2 border-green-300 rounded-lg overflow-hidden inline-block">
+              <img src={resultImageUrl} alt="fixed" className="max-w-full h-auto" style={{ maxHeight: '600px' }} />
+            </div>
+            <div className="mt-4 flex flex-wrap gap-3">
+              <button onClick={() => void downloadResult()} className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 flex items-center">
+                <Download className="mr-2" size={16} /> ダウンロード
+              </button>
+              <button onClick={useResultAsSource} className="px-6 py-2 bg-orange-100 text-orange-700 rounded hover:bg-orange-200 flex items-center">
+                <RotateCcw className="mr-2" size={16} /> この結果をさらに修正する
+              </button>
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FingerFixTab;

--- a/create_characters/character-pose/vite.config.ts
+++ b/create_characters/character-pose/vite.config.ts
@@ -5,4 +5,13 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: "/character_generator/",
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://ony6iblvbk.execute-api.ap-northeast-1.amazonaws.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, '/1'),
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- AI生成画像の指の本数を修正する「指修正」タブを新規追加
- 複数モデル切り替え対応（GPT Image 1.5 Edit / FLUX.2 Pro Edit / FLUX.1 Fill / Nano Banana Pro）
- 複数範囲選択・スケッチ補助・カラーピッカー・クローズアップ比較表示
- ポーズ生成タブの「指修正」ボタンから直接指修正タブに画像を渡す連携

## Test plan
- [ ] 指修正タブで画像アップロード → 範囲選択 → 各モデルで修正を実行
- [ ] スケッチ補助で指の位置をガイドして精度向上を確認
- [ ] 複数範囲選択（両手）で同時修正を確認
- [ ] ポーズ生成タブの指修正ボタンから指修正タブへの遷移を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)